### PR TITLE
Fix Ubuntu 18.04 script from having a user prompt

### DIFF
--- a/build/bootstrap/bootstrap-ubuntu-18.04.sh
+++ b/build/bootstrap/bootstrap-ubuntu-18.04.sh
@@ -17,7 +17,7 @@ apt-get install -y libboost-all-dev libgtest-dev libproxy-dev libmsgsl-dev libss
 # libssl-dev also required but installed above because plugin uses libssl-dev directly
 apt-get install -y zlib1g-dev
 
-apt install python-pip
+apt install -y python-pip
 pip install cpplint
 # Installs to a non-standard location so add to PATH manually
 export PATH=$PATH:~/.local/bin


### PR DESCRIPTION
This was impacting the adu agent build pipelines since they are now using our bootstrap scripts to provision DO. 