### PR TITLE
Add an equivalent api for explicitly setting DOCacheHost

### DIFF
--- a/sdk-cpp/include/do_config.h
+++ b/sdk-cpp/include/do_config.h
@@ -13,6 +13,8 @@ extern "C"
 // Returns: 0 on success, error code otherwise
 int deliveryoptimization_set_iot_connection_string(const char* value);
 
+int deliveryoptimization_set_cache_host(const char* value);
+
 // Future: Version and any future methods could be moved out from the extern C area
 // (and use C++ features) if ADU client does not have a need to call these from its lower layer.
 

--- a/sdk-cpp/src/do_config.cpp
+++ b/sdk-cpp/src/do_config.cpp
@@ -18,12 +18,34 @@ namespace msdoutil = microsoft::deliveryoptimization::util::details;
 const char* const g_dosvcBinName = DOSVC_BIN_NAME;
 const char* const g_doPluginAptBinName = DO_PLUGIN_APT_BIN_NAME;
 
+// Deprecated, but keeping here to not break API surface
 static int WriteIoTConnectionStringToConfigFile(const char* value) noexcept
 {
     try
     {
         boost::property_tree::ptree configTree;
         configTree.put("ADUC_IoTConnectionString", value);
+
+        // No other configs are used at this time so overwrite the whole file here
+        const std::string& filePath = microsoft::deliveryoptimization::details::GetConfigFilePath();
+        boost::property_tree::write_json(filePath, configTree);
+
+        return 0;
+    }
+    catch (const std::exception&)
+    {
+    }
+    // property_tree doesn't seem to offer an exception type that provides an error code.
+    // We do not (yet) log anything from the SDK either, so stick with returning -1 for all failure cases.
+    return -1;
+}
+
+static int WriteDOCacheHost(const char* value) noexcept
+{
+    try
+    {
+        boost::property_tree::ptree configTree;
+        configTree.put("DOCacheHost", value);
 
         // No other configs are used at this time so overwrite the whole file here
         const std::string& filePath = microsoft::deliveryoptimization::details::GetConfigFilePath();
@@ -135,6 +157,11 @@ static char* GetAllVersions()
         pBuffer[bufSize - 1] = '\0';
     }
     return pBuffer;
+}
+
+extern "C" int deliveryoptimization_set_cache_host(const char* value)
+{
+    return WriteDOCacheHost(value);
 }
 
 extern "C" int deliveryoptimization_set_iot_connection_string(const char* value)

--- a/sdk-cpp/tests/config_tests.cpp
+++ b/sdk-cpp/tests/config_tests.cpp
@@ -47,6 +47,20 @@ TEST_F(ConfigTests, IoTConnectionString)
     ASSERT_EQ(value, std::string{expectedValue});
 }
 
+TEST_F(ConfigTests, DOCacheHost)
+{
+    // [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Not credentials (false positive)")]
+    const char* expectedValue = "10.0.0.200";
+    int ret = deliveryoptimization_set_cache_host(expectedValue);
+    ASSERT_EQ(ret, 0);
+
+    boost::property_tree::ptree configTree;
+    boost::property_tree::read_json(msdod::GetConfigFilePath(), configTree);
+
+    const std::string value = configTree.get<std::string>("DOCacheHost");
+    ASSERT_EQ(value, std::string{ expectedValue });
+}
+
 TEST(ConfigVersionTests, GetVersion)
 {
     char* version = deliveryoptimization_get_components_version();


### PR DESCRIPTION
- Long-term mcc discoverability requires more thought - but this is an additional solution so as to still enable MCC while DU agent is using AIS