### PR TITLE
Support Ubuntu 20.04 arm64 builds and fix boost log linker issue

### DIFF
--- a/build/bootstrap/bootstrap-ubuntu-20.04.sh
+++ b/build/bootstrap/bootstrap-ubuntu-20.04.sh
@@ -1,0 +1,64 @@
+#! /bin/bash
+
+# bootstrap scripts will exit immediately if a command exits with a non-zero status
+set -e
+
+echo "Setting up development environment for do-client"
+
+# Various development machine tools
+apt-get update
+apt-get install -y build-essential g++ gdb gdbserver git wget
+apt-get install -y python3 cmake ninja-build rpm
+
+# Open-source library dependencies
+apt-get install -y libboost-all-dev libgtest-dev libproxy-dev libmsgsl-dev libssl-dev uuid-dev
+
+# Install cpprest dependencies
+# libssl-dev also required but installed above because plugin uses libssl-dev directly
+apt-get install -y zlib1g-dev
+
+# Cpprestsdk 2.10.2 is the latest publicly available version on Ubuntu 18.04
+# Build and install v2.10.16 as it's the earliest version which supports url-redirection
+mkdir /tmp/cpprestsdk
+cd /tmp/cpprestsdk
+git clone https://github.com/microsoft/cpprestsdk.git .
+git checkout tags/v2.10.16
+git submodule update --init
+mkdir /tmp/cpprestsdk/build
+cd /tmp/cpprestsdk/build
+cmake -G Ninja -DCMAKE_BUILD_TYPE=minsizerel -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTS=OFF -DBUILD_SAMPLES=OFF -Wno-dev -DWERROR=OFF ..
+ninja
+ninja install
+
+# The latest native-version of gtest on Ubuntu20.04 currently has a bug where CMakeLists doesn't declare an install target, causing 'make install' to fail
+# Clone from source and use release-1.10.0 instead, since gtest is a source package anyways 
+mkdir /tmp/gtest
+cd /tmp/gtest
+git clone https://github.com/google/googletest.git .
+git checkout release-1.10.0
+mkdir cmake 
+cd cmake
+cmake /tmp/gtest
+make 
+make install 
+
+if [[ "$1" == "--no-tools" ]]; then
+  echo "Skipping tools install"
+else
+  apt install -y python-pip
+  pip install cpplint
+  # Installs to a non-standard location so add to PATH manually
+  export PATH=$PATH:~/.local/bin
+
+  # Install docker to enable building cross-arch for arm
+  # Instructions located at: https://docs.docker.com/engine/install/ubuntu/
+  curl -fsSL https://get.docker.com -o get-docker.sh
+  sh get-docker.sh
+  # Install qemu for cross-arch support
+  apt-get -y install qemu binfmt-support qemu-user-static
+
+  # Register qemu with docker to more easily run cross-arch containers
+  docker run --rm --privileged multiarch/qemu-user-static --reset -p yes 
+fi
+
+echo "Finished bootstrapping"

--- a/build/bootstrap/bootstrap-ubuntu-20.04.sh
+++ b/build/bootstrap/bootstrap-ubuntu-20.04.sh
@@ -17,7 +17,7 @@ apt-get install -y libboost-all-dev libgtest-dev libproxy-dev libmsgsl-dev libss
 # libssl-dev also required but installed above because plugin uses libssl-dev directly
 apt-get install -y zlib1g-dev
 
-# Cpprestsdk 2.10.2 is the latest publicly available version on Ubuntu 18.04
+# Cpprestsdk 2.10.15 is the latest publicly available version on Ubuntu 20.04
 # Build and install v2.10.16 as it's the earliest version which supports url-redirection
 mkdir /tmp/cpprestsdk
 cd /tmp/cpprestsdk

--- a/build/docker/arm64/Ubuntu20.04/Dockerfile
+++ b/build/docker/arm64/Ubuntu20.04/Dockerfile
@@ -1,0 +1,45 @@
+# Dockerfile for building DO apt plugin for linux-arm (64bit).
+# First, install the docker extension for VSCode. Then you can right-click on this file
+# and choose Build Image. Give it a name and it will build the image.
+#
+# Open interactive terminal into the image in a container:
+# docker run -ti --rm --entrypoint=/bin/bash -v <project root dir>:/code -v <build root dir>:/build <image_name>
+# Example:
+# docker run -ti --rm --entrypoint=/bin/bash -v D:\do-client-lite:/code -v D:\temp\build_client_lite\arm-linux-debug:/build custom-ubuntu20.04-arm64
+
+FROM arm64v8/ubuntu:20.04
+
+SHELL [ "/bin/bash", "-c"]
+
+# QEMU is a Linux emulator which enables cross-arch support in docker
+# In order to build this image on a Linux host, need to install QEMU:
+#
+# sudo apt-get install qemu-user
+# update-binfmts --display
+# sudo apt install qemu binfmt-support qemu-user-static
+# cp /usr/bin/qemu-aarch64-static <src root>/build/docker/arm64/ubuntu20.04
+#
+# Then copy the build script to the build directory
+# cp <src root>/build/bootstrap/bootstrap-ubuntu-20.04.sh <src root>build/docker/arm64/ubuntu20.04
+#
+# After running the above, you can build the image by running in the current dockerfile directory
+# sudo docker build -t <your image name> . --no-cache --network=host
+
+# Ubuntu 20.04 requires user prompt for apt-get update command, docker has issues handling this input
+ENV DEBIAN_FRONTEND=noninteractive
+
+COPY qemu-aarch64-static /usr/bin/qemu-aarch64-static
+COPY bootstrap-ubuntu-20.04.sh /tmp/bootstrap-ubuntu-20.04.sh
+
+WORKDIR /tmp/
+RUN chmod +x bootstrap-ubuntu-20.04.sh
+RUN ./bootstrap-ubuntu-20.04.sh --no-tools
+
+ENTRYPOINT [ "/bin/bash", "-c"]
+
+# We specify an empty command so that we can pass options to the ENTRYPOINT command.
+# This is a bit of a Dockerfile quirk where if the ENTRYPOINT value is defined,
+# then CMD becomes the default options passed to ENTRYPOINT.
+# In this case we don't have any desired default arguments.
+# However, we have to specify CMD to enable passing of command line parameters to ENTRYPOINT in the first place.
+CMD [  ]

--- a/client-lite/CMakeLists.txt
+++ b/client-lite/CMakeLists.txt
@@ -7,7 +7,9 @@ project (${DOSVC_BIN_NAME} VERSION 0.4.0)
 option (DO_PROXY_SUPPORT "Set DO_PROXY_SUPPORT to OFF to turn off proxy support for downloads and thus remove dependency on libproxy." ON)
 
 add_definitions(-DBOOST_ALL_DYN_LINK=1)
-add_definitions(-DBOOST_LOG_DYN_LINK=1)
+# In more recent Boost versions, the posix dynamic linker (ld) has trouble linking to the right version of boost log
+# See: https://github.com/boostorg/log/issues/46
+add_definitions(-DBOOST_LOG_DYN_LINK=1) 
 
 # Get full debug info and also define DEBUG macro in debug builds
 string(TOLOWER ${CMAKE_BUILD_TYPE} DO_BUILD_TYPE)
@@ -115,8 +117,7 @@ target_link_libraries(${DOSVC_BIN_NAME}
     doversion
     docs_common
     cpprestsdk::cpprest
-    ${Boost_LIBRARIES}
-    ${Boost_LOG_LIBRARY})
+    ${Boost_LIBRARIES})
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     include(GNUInstallDirs)

--- a/client-lite/CMakeLists.txt
+++ b/client-lite/CMakeLists.txt
@@ -7,9 +7,6 @@ project (${DOSVC_BIN_NAME} VERSION 0.4.0)
 option (DO_PROXY_SUPPORT "Set DO_PROXY_SUPPORT to OFF to turn off proxy support for downloads and thus remove dependency on libproxy." ON)
 
 add_definitions(-DBOOST_ALL_DYN_LINK=1)
-# In more recent Boost versions, the posix dynamic linker (ld) has trouble linking to the right version of boost log
-# See: https://github.com/boostorg/log/issues/46
-add_definitions(-DBOOST_LOG_DYN_LINK=1) 
 
 # Get full debug info and also define DEBUG macro in debug builds
 string(TOLOWER ${CMAKE_BUILD_TYPE} DO_BUILD_TYPE)
@@ -113,11 +110,14 @@ add_do_version_lib(${PROJECT_NAME} ${PROJECT_VERSION})
 # Add the executable
 add_executable(${DOSVC_BIN_NAME} ${files_docs_exe})
 target_include_directories(${DOSVC_BIN_NAME} PRIVATE ${docs_common_includes})
+# For Ubuntu 20.04 support, need to explicitly link to Boost_LOG_LIBRARIES, breaking changes were made in later boost versions
+# See https://github.com/boostorg/log/issues/18 and https://github.com/boostorg/log/issues/46
 target_link_libraries(${DOSVC_BIN_NAME}
     doversion
     docs_common
     cpprestsdk::cpprest
-    ${Boost_LIBRARIES})
+    ${Boost_LIBRARIES}
+    ${Boost_LOG_LIBRARIES})
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     include(GNUInstallDirs)

--- a/client-lite/CMakeLists.txt
+++ b/client-lite/CMakeLists.txt
@@ -7,6 +7,7 @@ project (${DOSVC_BIN_NAME} VERSION 0.4.0)
 option (DO_PROXY_SUPPORT "Set DO_PROXY_SUPPORT to OFF to turn off proxy support for downloads and thus remove dependency on libproxy." ON)
 
 add_definitions(-DBOOST_ALL_DYN_LINK=1)
+add_definitions(-DBOOST_LOG_DYN_LINK=1)
 
 # Get full debug info and also define DEBUG macro in debug builds
 string(TOLOWER ${CMAKE_BUILD_TYPE} DO_BUILD_TYPE)
@@ -114,7 +115,8 @@ target_link_libraries(${DOSVC_BIN_NAME}
     doversion
     docs_common
     cpprestsdk::cpprest
-    ${Boost_LIBRARIES})
+    ${Boost_LIBRARIES}
+    ${Boost_LOG_LIBRARY})
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     include(GNUInstallDirs)


### PR DESCRIPTION
- Multiple people have attempted to build for Ubuntu 20.04 arm64, while helping troubleshoot their issues I needed a way to build locally as well.
- I added scripts to do the building via our docker solution
- For some reason, in the later boost versions, the linker (usr/bin/ld) had issues with selecting the right boost log version to link to, fix by explicitly including boost log libraries in target_include_libraries()