### PR TITLE
Check binary size growth in azure pipelines

### DIFF
--- a/azure-pipelines/build/templates/doclient-lite-native-steps.yml
+++ b/azure-pipelines/build/templates/doclient-lite-native-steps.yml
@@ -19,6 +19,14 @@ steps:
     arguments: '--project agent --config ${{parameters.config}} --package-for DEB --clean'
   displayName: 'Build agent ${{parameters.targetOsArch}}-${{parameters.config}}'
 
+- task: Bash@3
+  condition: eq('${{parameters.config}}', 'minsizerel')
+  inputs:
+    targetType: 'filePath'
+    filePath: 'build/check_binary_size.sh'
+    arguments: '/tmp/build-deliveryoptimization-agent/linux-${{parameters.config}}/client-lite/deliveryoptimization-agent 2314024'
+  displayName: 'Limit binary size increase'
+
 - task: CmdLine@2
   condition: eq('${{parameters.skipTests}}', false)
   inputs:

--- a/azure-pipelines/build/templates/dopapt-native-steps.yml
+++ b/azure-pipelines/build/templates/dopapt-native-steps.yml
@@ -31,6 +31,14 @@ steps:
     arguments: '--project plugin-apt --config ${{parameters.config}} --package-for DEB --clean'
   displayName: 'Build deliveryoptimization-plugin-apt ${{parameters.targetOsArch}}-${{parameters.config}}'
 
+- task: Bash@3
+  condition: eq('${{parameters.config}}', 'minsizerel')
+  inputs:
+    targetType: 'filePath'
+    filePath: 'build/check_binary_size.sh'
+    arguments: '/tmp/build-deliveryoptimization-plugin-apt/linux-${{parameters.config}}/plugins/linux-apt/deliveryoptimization-plugin-apt 172168'
+  displayName: 'Limit binary size increase'
+
 - task: CmdLine@2
   inputs:
     script: 'sudo dpkg -i deliveryoptimization-plugin-apt*.deb'

--- a/azure-pipelines/build/templates/dosdkcpp-native-steps.yml
+++ b/azure-pipelines/build/templates/dosdkcpp-native-steps.yml
@@ -34,6 +34,14 @@ steps:
     arguments: '--project sdk --cmaketarget deliveryoptimization --config ${{parameters.config}} --package-for DEB --clean'
   displayName: 'Build sdk-cpp ${{parameters.targetOsArch}}-${{parameters.config}}'
 
+- task: Bash@3
+  condition: eq('${{parameters.config}}', 'minsizerel')
+  inputs:
+    targetType: 'filePath'
+    filePath: 'build/check_binary_size.sh'
+    arguments: '/tmp/build-deliveryoptimization-sdk/linux-${{parameters.config}}/sdk-cpp/libdeliveryoptimization.so.*.*.* 2317304'
+  displayName: 'Limit binary size increase'
+
 - task: CmdLine@2
   condition: eq('${{parameters.skipTests}}', false)
   inputs:

--- a/build/check_binary_size.sh
+++ b/build/check_binary_size.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# <script.sh> <binary_size> <expected_size>
+if [ $# -lt 2 ]; then
+  echo "Usage: <script.sh> <binary_path> <expected_size>"
+  exit 1
+fi
+
+binary_path=$1
+expected_size=$2
+actual_size=`stat -c%s $binary_path`
+change_pct=`echo "scale=2; ($actual_size - $expected_size) / $expected_size * 100" | bc`
+echo Size check, expected = $expected_size, actual = $actual_size, change pct = $change_pct%
+change_pct=$( printf "%.0f" $change_pct )
+if [ $change_pct -gt 10 ]; then
+    echo "Size check FAIL. Adjust expected_size if this increase is expected."
+    exit 2
+fi

--- a/build/check_binary_size.sh
+++ b/build/check_binary_size.sh
@@ -12,7 +12,7 @@ actual_size=`stat -c%s $binary_path`
 change_pct=`echo "scale=2; ($actual_size - $expected_size) / $expected_size * 100" | bc`
 echo Size check, expected = $expected_size, actual = $actual_size, change pct = $change_pct%
 change_pct=$( printf "%.0f" $change_pct )
-if [ $change_pct -gt 10 ]; then
+if [ $change_pct -ge 5 ]; then
     echo "Size check FAIL. Adjust expected_size if this increase is expected."
     exit 2
 fi


### PR DESCRIPTION
* Check runs only for minsizerel flavor.
* Baseline number obtained from local dev build.
* Binary size increase of 5% or more results in build failure.