### PR TITLE
Enable versioning for build images

### DIFF
--- a/azure-pipelines/build/doclient-lite-docker.yml
+++ b/azure-pipelines/build/doclient-lite-docker.yml
@@ -20,7 +20,7 @@ variables:
 
 pool: 
   name: 1es_hosted_pool_ubuntu_1804
-  vmImage: do-adu-build-${{variables.version}}
+  vmImage: do-adu-build-$(variables.version)
 
 jobs:
 - template: templates/do-docker-jobs.yml

--- a/azure-pipelines/build/doclient-lite-docker.yml
+++ b/azure-pipelines/build/doclient-lite-docker.yml
@@ -27,18 +27,18 @@ pool:
 jobs:
 - template: templates/do-docker-jobs.yml
   parameters:
-    targetOsArch: 'debian9-arm32'
+    targetOsArch: 'debian9_arm32'
     version: ${{variables.version}}
     stepsTemplate: 'doclient-lite-docker-steps.yml'
 
 - template: templates/do-docker-jobs.yml
   parameters:
-    targetOsArch: 'debian10-arm32'
+    targetOsArch: 'debian10_arm32'
     version: ${{variables.version}}
     stepsTemplate: 'doclient-lite-docker-steps.yml'
 
 - template: templates/do-docker-jobs.yml
   parameters:
-    targetOsArch: 'ubuntu1804-arm64' # azure pipelines does not support '.' in display names
+    targetOsArch: 'ubuntu1804_arm64' # azure pipelines does not support '.' in display names
     version: ${{variables.version}}
     stepsTemplate: 'doclient-lite-docker-steps.yml'

--- a/azure-pipelines/build/doclient-lite-docker.yml
+++ b/azure-pipelines/build/doclient-lite-docker.yml
@@ -20,7 +20,9 @@ variables:
 
 pool: 
   name: 1es_hosted_pool_ubuntu_1804
-  vmImage: do-adu-build-$(version)
+  #TODO(jimson): After Imagefactory check-in is completed and we can create new image, use the commented below
+  #vmImage: do-adu-build-$(version)
+  vmImage: do-adu-build-2
 
 jobs:
 - template: templates/do-docker-jobs.yml

--- a/azure-pipelines/build/doclient-lite-docker.yml
+++ b/azure-pipelines/build/doclient-lite-docker.yml
@@ -1,6 +1,10 @@
 # Pipeline to build DO Agent using docker to target non-native OS and/or architecture.
 # Publishes the binaries + packages as artifacts.
 
+variables:
+- name: version
+  value: 0.8.0
+
 # Disable branch and pr triggers - currently run this manually to avoid hogging build machine resources
 # Rely on Ubuntu x64 pipeline for CI/CD
 trigger:
@@ -13,10 +17,6 @@ schedules:
   branches:
     include:
     - main
-
-variables:
-- name: version
-  value: 0.8.0
 
 pool: 
   name: 1es_hosted_pool_ubuntu_1804

--- a/azure-pipelines/build/doclient-lite-docker.yml
+++ b/azure-pipelines/build/doclient-lite-docker.yml
@@ -25,18 +25,18 @@ pool:
 jobs:
 - template: templates/do-docker-jobs.yml
   parameters:
-    targetOsArch: 'debian9_arm32'
+    targetOsArch: 'debian9-arm32'
     version: ${{variables.version}}
     stepsTemplate: 'doclient-lite-docker-steps.yml'
 
 - template: templates/do-docker-jobs.yml
   parameters:
-    targetOsArch: 'debian10_arm32'
+    targetOsArch: 'debian10-arm32'
     version: ${{variables.version}}
     stepsTemplate: 'doclient-lite-docker-steps.yml'
 
 - template: templates/do-docker-jobs.yml
   parameters:
-    targetOsArch: 'ubuntu1804_arm64' # azure pipelines does not support '.' in display names
+    targetOsArch: 'ubuntu1804-arm64' # azure pipelines does not support '.' in display names
     version: ${{variables.version}}
     stepsTemplate: 'doclient-lite-docker-steps.yml'

--- a/azure-pipelines/build/doclient-lite-docker.yml
+++ b/azure-pipelines/build/doclient-lite-docker.yml
@@ -20,25 +20,23 @@ schedules:
 
 pool: 
   name: 1es_hosted_pool_ubuntu_1804
-  #TODO(jimson): After Imagefactory check-in is completed and we can create new image, use the commented below
-  #vmImage: do-adu-build-$(version)
-  vmImage: do-adu-build-2
+  vmImage: do-adu-build-$(version)
 
 jobs:
 - template: templates/do-docker-jobs.yml
   parameters:
     targetOsArch: 'debian9_arm32'
-    version: ${{variables.version}}
+    version: ${{variables.imageVersion}}
     stepsTemplate: 'doclient-lite-docker-steps.yml'
 
 - template: templates/do-docker-jobs.yml
   parameters:
     targetOsArch: 'debian10_arm32'
-    version: ${{variables.version}}
+    version: ${{variables.imageVersion}}
     stepsTemplate: 'doclient-lite-docker-steps.yml'
 
 - template: templates/do-docker-jobs.yml
   parameters:
     targetOsArch: 'ubuntu1804_arm64' # azure pipelines does not support '.' in display names
-    version: ${{variables.version}}
+    version: ${{variables.imageVersion}}
     stepsTemplate: 'doclient-lite-docker-steps.yml'

--- a/azure-pipelines/build/doclient-lite-docker.yml
+++ b/azure-pipelines/build/doclient-lite-docker.yml
@@ -2,7 +2,7 @@
 # Publishes the binaries + packages as artifacts.
 
 variables:
-- name: version
+- name: imageVersion # This is used to specify the vmImage & dockerImage to build the current release, this version # will always be the subsequent release in development branches
   value: 0.8.0
 
 # Disable branch and pr triggers - currently run this manually to avoid hogging build machine resources

--- a/azure-pipelines/build/doclient-lite-docker.yml
+++ b/azure-pipelines/build/doclient-lite-docker.yml
@@ -20,7 +20,7 @@ variables:
 
 pool: 
   name: 1es_hosted_pool_ubuntu_1804
-  vmImage: do-adu-build-$(variables.version)
+  vmImage: do-adu-build-$(version)
 
 jobs:
 - template: templates/do-docker-jobs.yml

--- a/azure-pipelines/build/doclient-lite-docker.yml
+++ b/azure-pipelines/build/doclient-lite-docker.yml
@@ -20,7 +20,7 @@ schedules:
 
 pool: 
   name: 1es_hosted_pool_ubuntu_1804
-  vmImage: do-adu-build-$(version)
+  vmImage: do-adu-build-$(imageVersion)
 
 jobs:
 - template: templates/do-docker-jobs.yml

--- a/azure-pipelines/build/doclient-lite-docker.yml
+++ b/azure-pipelines/build/doclient-lite-docker.yml
@@ -14,7 +14,14 @@ schedules:
     include:
     - main
 
-pool: 1es_hosted_pool_ubuntu_1804
+variables:
+- name: version
+  type: string
+  default: v0.8.0
+
+pool: 
+  name: 1es_hosted_pool_ubuntu_1804
+  vmImage: do-adu-build-($(version))
 
 jobs:
 - template: templates/do-docker-jobs.yml

--- a/azure-pipelines/build/doclient-lite-docker.yml
+++ b/azure-pipelines/build/doclient-lite-docker.yml
@@ -16,25 +16,27 @@ schedules:
 
 variables:
 - name: version
-  type: string
-  default: v0.8.0
+  value: 0.8.0
 
 pool: 
   name: 1es_hosted_pool_ubuntu_1804
-  vmImage: do-adu-build-($(version))
+  vmImage: do-adu-build-${{variables.version}}
 
 jobs:
 - template: templates/do-docker-jobs.yml
   parameters:
     targetOsArch: 'debian9_arm32'
+    version: ${{variables.version}}
     stepsTemplate: 'doclient-lite-docker-steps.yml'
 
 - template: templates/do-docker-jobs.yml
   parameters:
     targetOsArch: 'debian10_arm32'
+    version: ${{variables.version}}
     stepsTemplate: 'doclient-lite-docker-steps.yml'
 
 - template: templates/do-docker-jobs.yml
   parameters:
     targetOsArch: 'ubuntu1804_arm64' # azure pipelines does not support '.' in display names
+    version: ${{variables.version}}
     stepsTemplate: 'doclient-lite-docker-steps.yml'

--- a/azure-pipelines/build/doclient-lite-native.yml
+++ b/azure-pipelines/build/doclient-lite-native.yml
@@ -2,7 +2,7 @@
 # Publishes the binaries + packages as artifacts.
 
 variables:
-- name: version
+- name: imageVersion
   value: 0.8.0
 
 trigger:

--- a/azure-pipelines/build/doclient-lite-native.yml
+++ b/azure-pipelines/build/doclient-lite-native.yml
@@ -37,9 +37,7 @@ pr:
 
 pool: 
   name: 1es_hosted_pool_ubuntu_1804
-  #TODO(jimson): After Imagefactory check-in is completed and we can create new image, use the commented below
-  #vmImage: do-adu-build-$(version)
-  vmImage: do-adu-build-2
+  vmImage: do-adu-build-$(version)
 
 jobs:
 - job: Debug

--- a/azure-pipelines/build/doclient-lite-native.yml
+++ b/azure-pipelines/build/doclient-lite-native.yml
@@ -37,7 +37,7 @@ pr:
 
 pool: 
   name: 1es_hosted_pool_ubuntu_1804
-  vmImage: do-adu-build-$(version)
+  vmImage: do-adu-build-$(imageVersion)
 
 jobs:
 - job: Debug

--- a/azure-pipelines/build/doclient-lite-native.yml
+++ b/azure-pipelines/build/doclient-lite-native.yml
@@ -43,7 +43,9 @@ variables:
 
 pool: 
   name: 1es_hosted_pool_ubuntu_1804
-  vmImage: do-adu-build-$(version)
+  #TODO(jimson): After Imagefactory check-in is completed and we can create new image, use the commented below
+  #vmImage: do-adu-build-$(version)
+  vmImage: do-adu-build-2
 
 jobs:
 - job: Debug

--- a/azure-pipelines/build/doclient-lite-native.yml
+++ b/azure-pipelines/build/doclient-lite-native.yml
@@ -37,20 +37,26 @@ pr:
     exclude:
       - azure-pipelines/*
 
-pool: 1es_hosted_pool_ubuntu_1804
+variables:
+- name: version
+  value: 0.8.0
+
+pool: 
+  name: 1es_hosted_pool_ubuntu_1804
+  vmImage: do-adu-build-$(version)
 
 jobs:
 - job: Debug
   steps:
   - template: templates/doclient-lite-native-steps.yml
     parameters:
-      targetOsArch: 'ubuntu1804_x64'
+      targetOsArch: 'ubuntu1804-x64'
       config: debug
 
 - job: Release
   steps:
   - template: templates/doclient-lite-native-steps.yml
     parameters:
-      targetOsArch: 'ubuntu1804_x64'
+      targetOsArch: 'ubuntu1804-x64'
       config: minsizerel
       skipTests: true

--- a/azure-pipelines/build/doclient-lite-native.yml
+++ b/azure-pipelines/build/doclient-lite-native.yml
@@ -1,11 +1,9 @@
 # Pipeline to build DO Agent targeting x86-64 architecture.
 # Publishes the binaries + packages as artifacts.
 
-# Version here refers to test package version, and follows format of 0.0.<Pipeline Build Number>
-# This is due to azure universal packaging apis requiring semantic versioning
-# Builds are monotonically increasing based on run number so test builds can always pull the newest version
 variables:
-  test.package.version: 0.0.$(Build.BuildId)
+- name: version
+  value: 0.8.0
 
 trigger:
   branches:
@@ -36,10 +34,6 @@ pr:
       - CMakeLists.txt
     exclude:
       - azure-pipelines/*
-
-variables:
-- name: version
-  value: 0.8.0
 
 pool: 
   name: 1es_hosted_pool_ubuntu_1804

--- a/azure-pipelines/build/doclient-lite-native.yml
+++ b/azure-pipelines/build/doclient-lite-native.yml
@@ -52,13 +52,13 @@ jobs:
   steps:
   - template: templates/doclient-lite-native-steps.yml
     parameters:
-      targetOsArch: 'ubuntu1804-x64'
+      targetOsArch: 'ubuntu1804_x64'
       config: debug
 
 - job: Release
   steps:
   - template: templates/doclient-lite-native-steps.yml
     parameters:
-      targetOsArch: 'ubuntu1804-x64'
+      targetOsArch: 'ubuntu1804_x64'
       config: minsizerel
       skipTests: true

--- a/azure-pipelines/build/dopapt-docker.yml
+++ b/azure-pipelines/build/dopapt-docker.yml
@@ -1,6 +1,10 @@
 # Pipeline to build DO Plugins using docker to target non-native OS and/or architecture.
 # Publishes the binaries + packages as artifacts.
 
+variables:
+- name: version
+  value: 0.8.0
+
 # Disable branch and pr triggers - currently run this manually to avoid hogging build machine resources
 # Rely on Ubuntu x64 pipeline for CI/CD
 trigger:
@@ -13,10 +17,6 @@ schedules:
   branches:
     include:
     - main
-
-variables:
-- name: version
-  value: 0.8.0
 
 pool: 
   name: 1es_hosted_pool_ubuntu_1804

--- a/azure-pipelines/build/dopapt-docker.yml
+++ b/azure-pipelines/build/dopapt-docker.yml
@@ -20,7 +20,9 @@ variables:
 
 pool: 
   name: 1es_hosted_pool_ubuntu_1804
-  vmImage: do-adu-build-$(version)
+  #TODO(jimson): After Imagefactory check-in is completed and we can create new image, use the commented below
+  #vmImage: do-adu-build-$(version)
+  vmImage: do-adu-build-2
 
 jobs:
 - template: templates/do-docker-jobs.yml

--- a/azure-pipelines/build/dopapt-docker.yml
+++ b/azure-pipelines/build/dopapt-docker.yml
@@ -20,25 +20,23 @@ schedules:
 
 pool: 
   name: 1es_hosted_pool_ubuntu_1804
-  #TODO(jimson): After Imagefactory check-in is completed and we can create new image, use the commented below
-  #vmImage: do-adu-build-$(version)
-  vmImage: do-adu-build-2
+  vmImage: do-adu-build-$(version)
 
 jobs:
 - template: templates/do-docker-jobs.yml
   parameters:
     targetOsArch: 'debian10_arm32'
-    version: ${{variables.version}}
+    version: ${{variables.imageVersion}}
     stepsTemplate: 'dopapt-docker-steps.yml'
 
 - template: templates/do-docker-jobs.yml
   parameters:
     targetOsArch: 'debian9_arm32'
-    version: ${{variables.version}}
+    version: ${{variables.imageVersion}}
     stepsTemplate: 'dopapt-docker-steps.yml'
 
 - template: templates/do-docker-jobs.yml
   parameters:
     targetOsArch: 'ubuntu1804_arm64'
-    version: ${{variables.version}}
+    version: ${{variables.imageVersion}}
     stepsTemplate: 'dopapt-docker-steps.yml'

--- a/azure-pipelines/build/dopapt-docker.yml
+++ b/azure-pipelines/build/dopapt-docker.yml
@@ -20,12 +20,12 @@ variables:
 
 pool: 
   name: 1es_hosted_pool_ubuntu_1804
-  vmImage: do-adu-build-($(version))
+  vmImage: do-adu-build-$(version)
 
 jobs:
 - template: templates/do-docker-jobs.yml
   parameters:
-    targetOsArch: 'debian10_arm32'
+    targetOsArch: 'debian10-arm32'
     version: ${{variables.version}}
     stepsTemplate: 'dopapt-docker-steps.yml'
 
@@ -37,6 +37,6 @@ jobs:
 
 - template: templates/do-docker-jobs.yml
   parameters:
-    targetOsArch: 'ubuntu1804_arm64'
+    targetOsArch: 'ubuntu1804-arm64'
     version: ${{variables.version}}
     stepsTemplate: 'dopapt-docker-steps.yml'

--- a/azure-pipelines/build/dopapt-docker.yml
+++ b/azure-pipelines/build/dopapt-docker.yml
@@ -20,7 +20,7 @@ schedules:
 
 pool: 
   name: 1es_hosted_pool_ubuntu_1804
-  vmImage: do-adu-build-$(version)
+  vmImage: do-adu-build-$(imageVersion)
 
 jobs:
 - template: templates/do-docker-jobs.yml

--- a/azure-pipelines/build/dopapt-docker.yml
+++ b/azure-pipelines/build/dopapt-docker.yml
@@ -14,20 +14,29 @@ schedules:
     include:
     - main
 
-pool: 1es_hosted_pool_ubuntu_1804
+variables:
+- name: version
+  value: 0.8.0
+
+pool: 
+  name: 1es_hosted_pool_ubuntu_1804
+  vmImage: do-adu-build-($(version))
 
 jobs:
 - template: templates/do-docker-jobs.yml
   parameters:
     targetOsArch: 'debian10_arm32'
+    version: ${{variables.version}}
     stepsTemplate: 'dopapt-docker-steps.yml'
 
 - template: templates/do-docker-jobs.yml
   parameters:
     targetOsArch: 'debian9_arm32'
+    version: ${{variables.version}}
     stepsTemplate: 'dopapt-docker-steps.yml'
 
 - template: templates/do-docker-jobs.yml
   parameters:
     targetOsArch: 'ubuntu1804_arm64'
+    version: ${{variables.version}}
     stepsTemplate: 'dopapt-docker-steps.yml'

--- a/azure-pipelines/build/dopapt-docker.yml
+++ b/azure-pipelines/build/dopapt-docker.yml
@@ -2,7 +2,7 @@
 # Publishes the binaries + packages as artifacts.
 
 variables:
-- name: version
+- name: imageVersion
   value: 0.8.0
 
 # Disable branch and pr triggers - currently run this manually to avoid hogging build machine resources

--- a/azure-pipelines/build/dopapt-docker.yml
+++ b/azure-pipelines/build/dopapt-docker.yml
@@ -27,7 +27,7 @@ pool:
 jobs:
 - template: templates/do-docker-jobs.yml
   parameters:
-    targetOsArch: 'debian10-arm32'
+    targetOsArch: 'debian10_arm32'
     version: ${{variables.version}}
     stepsTemplate: 'dopapt-docker-steps.yml'
 
@@ -39,6 +39,6 @@ jobs:
 
 - template: templates/do-docker-jobs.yml
   parameters:
-    targetOsArch: 'ubuntu1804-arm64'
+    targetOsArch: 'ubuntu1804_arm64'
     version: ${{variables.version}}
     stepsTemplate: 'dopapt-docker-steps.yml'

--- a/azure-pipelines/build/dopapt-native.yml
+++ b/azure-pipelines/build/dopapt-native.yml
@@ -2,7 +2,7 @@
 # Publishes the binaries + packages as artifacts.
 
 variables:
-- name: version
+- name: imageVersion
   value: 0.8.0
 
 trigger:

--- a/azure-pipelines/build/dopapt-native.yml
+++ b/azure-pipelines/build/dopapt-native.yml
@@ -45,7 +45,9 @@ variables:
 
 pool: 
   name: 1es_hosted_pool_ubuntu_1804
-  vmImage: do-adu-build-$(version)
+  #TODO(jimson): After Imagefactory check-in is completed and we can create new image, use the commented below
+  #vmImage: do-adu-build-$(version)
+  vmImage: do-adu-build-2
 
 jobs:
 - job: Debug

--- a/azure-pipelines/build/dopapt-native.yml
+++ b/azure-pipelines/build/dopapt-native.yml
@@ -54,12 +54,12 @@ jobs:
   steps:
   - template: templates/dopapt-native-steps.yml
     parameters:
-      targetOsArch: 'ubuntu1804-x64'
+      targetOsArch: 'ubuntu1804_x64'
       config: debug
 
 - job: Release
   steps:
   - template: templates/dopapt-native-steps.yml
     parameters:
-      targetOsArch: 'ubuntu1804-x64'
+      targetOsArch: 'ubuntu1804_x64'
       config: minsizerel

--- a/azure-pipelines/build/dopapt-native.yml
+++ b/azure-pipelines/build/dopapt-native.yml
@@ -39,19 +39,25 @@ pr:
       - 'azure-pipelines/*'
       - 'plugins/linux-apt/scripts/configure-apt-method.sh'
 
-pool: 1es_hosted_pool_ubuntu_1804
+variables:
+- name: version
+  value: 0.8.0
+
+pool: 
+  name: 1es_hosted_pool_ubuntu_1804
+  vmImage: do-adu-build-$(version)
 
 jobs:
 - job: Debug
   steps:
   - template: templates/dopapt-native-steps.yml
     parameters:
-      targetOsArch: 'ubuntu1804_x64'
+      targetOsArch: 'ubuntu1804-x64'
       config: debug
 
 - job: Release
   steps:
   - template: templates/dopapt-native-steps.yml
     parameters:
-      targetOsArch: 'ubuntu1804_x64'
+      targetOsArch: 'ubuntu1804-x64'
       config: minsizerel

--- a/azure-pipelines/build/dopapt-native.yml
+++ b/azure-pipelines/build/dopapt-native.yml
@@ -39,9 +39,7 @@ pr:
 
 pool: 
   name: 1es_hosted_pool_ubuntu_1804
-  #TODO(jimson): After Imagefactory check-in is completed and we can create new image, use the commented below
-  #vmImage: do-adu-build-$(version)
-  vmImage: do-adu-build-2
+  vmImage: do-adu-build-$(version)
 
 jobs:
 - job: Debug

--- a/azure-pipelines/build/dopapt-native.yml
+++ b/azure-pipelines/build/dopapt-native.yml
@@ -1,11 +1,9 @@
 # Pipeline to build DO Plugins targeting x86-64 architecture.
 # Publishes the binaries + packages as artifacts.
 
-# Version here refers to test package version, and follows format of 0.0.<Pipeline Build Number>
-# This is due to azure universal packaging apis requiring semantic versioning
-# Builds are monotonically increasing based on run number so test builds can always pull the newest version
 variables:
-  test.package.version: 0.0.$(Build.BuildId)
+- name: version
+  value: 0.8.0
 
 trigger:
   branches:
@@ -38,10 +36,6 @@ pr:
     exclude:
       - 'azure-pipelines/*'
       - 'plugins/linux-apt/scripts/configure-apt-method.sh'
-
-variables:
-- name: version
-  value: 0.8.0
 
 pool: 
   name: 1es_hosted_pool_ubuntu_1804

--- a/azure-pipelines/build/dopapt-native.yml
+++ b/azure-pipelines/build/dopapt-native.yml
@@ -39,7 +39,7 @@ pr:
 
 pool: 
   name: 1es_hosted_pool_ubuntu_1804
-  vmImage: do-adu-build-$(version)
+  vmImage: do-adu-build-$(imageVersion)
 
 jobs:
 - job: Debug

--- a/azure-pipelines/build/dosdkcpp-docker.yml
+++ b/azure-pipelines/build/dosdkcpp-docker.yml
@@ -20,25 +20,23 @@ schedules:
 
 pool: 
   name: 1es_hosted_pool_ubuntu_1804
-  #TODO(jimson): After Imagefactory check-in is completed and we can create new image, use the commented below
-  #vmImage: do-adu-build-$(version)
-  vmImage: do-adu-build-2
+  vmImage: do-adu-build-$(version)
 
 jobs:
 - template: templates/do-docker-jobs.yml
   parameters:
     targetOsArch: 'debian10_arm32'
-    version: ${{variables.version}}
+    version: ${{variables.imageVersion}}
     stepsTemplate: 'dosdkcpp-docker-steps.yml'
 
 - template: templates/do-docker-jobs.yml
   parameters:
     targetOsArch: 'debian9_arm32'
-    version: ${{variables.version}}
+    version: ${{variables.imageVersion}}
     stepsTemplate: 'dosdkcpp-docker-steps.yml'
 
 - template: templates/do-docker-jobs.yml
   parameters:
     targetOsArch: 'ubuntu1804_arm64'
-    version: ${{variables.version}}
+    version: ${{variables.imageVersion}}
     stepsTemplate: 'dosdkcpp-docker-steps.yml'

--- a/azure-pipelines/build/dosdkcpp-docker.yml
+++ b/azure-pipelines/build/dosdkcpp-docker.yml
@@ -20,7 +20,9 @@ variables:
 
 pool: 
   name: 1es_hosted_pool_ubuntu_1804
-  vmImage: do-adu-build-$(version)
+  #TODO(jimson): After Imagefactory check-in is completed and we can create new image, use the commented below
+  #vmImage: do-adu-build-$(version)
+  vmImage: do-adu-build-2
 
 jobs:
 - template: templates/do-docker-jobs.yml

--- a/azure-pipelines/build/dosdkcpp-docker.yml
+++ b/azure-pipelines/build/dosdkcpp-docker.yml
@@ -1,6 +1,10 @@
 # Pipeline to build DO C++ SDK using docker to target non-native OS and/or architecture.
 # Publishes the binaries + packages as artifacts.
 
+variables:
+- name: version
+  value: 0.8.0
+
 # Disable branch and pr triggers - currently run this manually to avoid hogging build machine resources
 # Rely on Ubuntu x64 pipeline for CI/CD
 trigger:
@@ -13,10 +17,6 @@ schedules:
   branches:
     include:
     - main
-
-variables:
-- name: version
-  value: 0.8.0
 
 pool: 
   name: 1es_hosted_pool_ubuntu_1804

--- a/azure-pipelines/build/dosdkcpp-docker.yml
+++ b/azure-pipelines/build/dosdkcpp-docker.yml
@@ -20,14 +20,17 @@ jobs:
 - template: templates/do-docker-jobs.yml
   parameters:
     targetOsArch: 'debian10_arm32'
+    version: ${{variables.version}}
     stepsTemplate: 'dosdkcpp-docker-steps.yml'
 
 - template: templates/do-docker-jobs.yml
   parameters:
     targetOsArch: 'debian9_arm32'
+    version: ${{variables.version}}
     stepsTemplate: 'dosdkcpp-docker-steps.yml'
 
 - template: templates/do-docker-jobs.yml
   parameters:
     targetOsArch: 'ubuntu1804_arm64'
+    version: ${{variables.version}}
     stepsTemplate: 'dosdkcpp-docker-steps.yml'

--- a/azure-pipelines/build/dosdkcpp-docker.yml
+++ b/azure-pipelines/build/dosdkcpp-docker.yml
@@ -20,7 +20,7 @@ schedules:
 
 pool: 
   name: 1es_hosted_pool_ubuntu_1804
-  vmImage: do-adu-build-$(version)
+  vmImage: do-adu-build-$(imageVersion)
 
 jobs:
 - template: templates/do-docker-jobs.yml

--- a/azure-pipelines/build/dosdkcpp-docker.yml
+++ b/azure-pipelines/build/dosdkcpp-docker.yml
@@ -2,7 +2,7 @@
 # Publishes the binaries + packages as artifacts.
 
 variables:
-- name: version
+- name: imageVersion
   value: 0.8.0
 
 # Disable branch and pr triggers - currently run this manually to avoid hogging build machine resources

--- a/azure-pipelines/build/dosdkcpp-docker.yml
+++ b/azure-pipelines/build/dosdkcpp-docker.yml
@@ -14,23 +14,29 @@ schedules:
     include:
     - main
 
-pool: 1es_hosted_pool_ubuntu_1804
+variables:
+- name: version
+  value: 0.8.0
+
+pool: 
+  name: 1es_hosted_pool_ubuntu_1804
+  vmImage: do-adu-build-$(version)
 
 jobs:
 - template: templates/do-docker-jobs.yml
   parameters:
-    targetOsArch: 'debian10_arm32'
+    targetOsArch: 'debian10-arm32'
     version: ${{variables.version}}
     stepsTemplate: 'dosdkcpp-docker-steps.yml'
 
 - template: templates/do-docker-jobs.yml
   parameters:
-    targetOsArch: 'debian9_arm32'
+    targetOsArch: 'debian9-arm32'
     version: ${{variables.version}}
     stepsTemplate: 'dosdkcpp-docker-steps.yml'
 
 - template: templates/do-docker-jobs.yml
   parameters:
-    targetOsArch: 'ubuntu1804_arm64'
+    targetOsArch: 'ubuntu1804-arm64'
     version: ${{variables.version}}
     stepsTemplate: 'dosdkcpp-docker-steps.yml'

--- a/azure-pipelines/build/dosdkcpp-docker.yml
+++ b/azure-pipelines/build/dosdkcpp-docker.yml
@@ -27,18 +27,18 @@ pool:
 jobs:
 - template: templates/do-docker-jobs.yml
   parameters:
-    targetOsArch: 'debian10-arm32'
+    targetOsArch: 'debian10_arm32'
     version: ${{variables.version}}
     stepsTemplate: 'dosdkcpp-docker-steps.yml'
 
 - template: templates/do-docker-jobs.yml
   parameters:
-    targetOsArch: 'debian9-arm32'
+    targetOsArch: 'debian9_arm32'
     version: ${{variables.version}}
     stepsTemplate: 'dosdkcpp-docker-steps.yml'
 
 - template: templates/do-docker-jobs.yml
   parameters:
-    targetOsArch: 'ubuntu1804-arm64'
+    targetOsArch: 'ubuntu1804_arm64'
     version: ${{variables.version}}
     stepsTemplate: 'dosdkcpp-docker-steps.yml'

--- a/azure-pipelines/build/dosdkcpp-native.yml
+++ b/azure-pipelines/build/dosdkcpp-native.yml
@@ -46,20 +46,22 @@ variables:
 
 pool: 
   name: 1es_hosted_pool_ubuntu_1804
-  vmImage: do-adu-build-$(version)
+  #TODO(jimson): After Imagefactory check-in is completed and we can create new image, use the commented below
+  #vmImage: do-adu-build-$(version)
+  vmImage: do-adu-build-2
 
 jobs:
 - job: Debug
   steps:
   - template: templates/dosdkcpp-native-steps.yml
     parameters:
-      targetOsArch: 'ubuntu1804_x64'
+      targetOsArch: 'ubuntu1804-x64'
       config: debug
 
 - job: Release
   steps:
   - template: templates/dosdkcpp-native-steps.yml
     parameters:
-      targetOsArch: 'ubuntu1804_x64'
+      targetOsArch: 'ubuntu1804-x64'
       config: minsizerel
       skipTests: true

--- a/azure-pipelines/build/dosdkcpp-native.yml
+++ b/azure-pipelines/build/dosdkcpp-native.yml
@@ -40,7 +40,7 @@ pr:
 
 pool: 
   name: 1es_hosted_pool_ubuntu_1804
-  vmImage: do-adu-build-$(version)
+  vmImage: do-adu-build-$(imageVersion)
 
 jobs:
 - job: Debug

--- a/azure-pipelines/build/dosdkcpp-native.yml
+++ b/azure-pipelines/build/dosdkcpp-native.yml
@@ -2,11 +2,9 @@
 # Client-lite is built for running tests alone, it is not published.
 # Publishes the binaries + packages as artifacts.
 
-# Version here refers to test package version, and follows format of 0.0.<Pipeline Build Number>
-# This is due to azure universal packaging apis requiring semantic versioning
-# Builds are monotonically increasing based on run number so test builds can always pull the newest version
 variables:
-  test.package.version: 0.0.$(Build.BuildId)
+- name: version
+  value: 0.8.0
 
 trigger:
   branches:
@@ -39,10 +37,6 @@ pr:
     exclude:
       - azure-pipelines/*
       - sdk-cpp/build/cleanup-install.sh
-
-variables:
-- name: version
-  value: 0.8.0
 
 pool: 
   name: 1es_hosted_pool_ubuntu_1804

--- a/azure-pipelines/build/dosdkcpp-native.yml
+++ b/azure-pipelines/build/dosdkcpp-native.yml
@@ -40,9 +40,7 @@ pr:
 
 pool: 
   name: 1es_hosted_pool_ubuntu_1804
-  #TODO(jimson): After Imagefactory check-in is completed and we can create new image, use the commented below
-  #vmImage: do-adu-build-$(version)
-  vmImage: do-adu-build-2
+  vmImage: do-adu-build-$(version)
 
 jobs:
 - job: Debug

--- a/azure-pipelines/build/dosdkcpp-native.yml
+++ b/azure-pipelines/build/dosdkcpp-native.yml
@@ -55,13 +55,13 @@ jobs:
   steps:
   - template: templates/dosdkcpp-native-steps.yml
     parameters:
-      targetOsArch: 'ubuntu1804-x64'
+      targetOsArch: 'ubuntu1804_x64'
       config: debug
 
 - job: Release
   steps:
   - template: templates/dosdkcpp-native-steps.yml
     parameters:
-      targetOsArch: 'ubuntu1804-x64'
+      targetOsArch: 'ubuntu1804_x64'
       config: minsizerel
       skipTests: true

--- a/azure-pipelines/build/dosdkcpp-native.yml
+++ b/azure-pipelines/build/dosdkcpp-native.yml
@@ -3,7 +3,7 @@
 # Publishes the binaries + packages as artifacts.
 
 variables:
-- name: version
+- name: imageVersion
   value: 0.8.0
 
 trigger:

--- a/azure-pipelines/build/dosdkcpp-native.yml
+++ b/azure-pipelines/build/dosdkcpp-native.yml
@@ -40,7 +40,13 @@ pr:
       - azure-pipelines/*
       - sdk-cpp/build/cleanup-install.sh
 
-pool: 1es_hosted_pool_ubuntu_1804
+variables:
+- name: version
+  value: 0.8.0
+
+pool: 
+  name: 1es_hosted_pool_ubuntu_1804
+  vmImage: do-adu-build-$(version)
 
 jobs:
 - job: Debug

--- a/azure-pipelines/build/templates/do-docker-jobs.yml
+++ b/azure-pipelines/build/templates/do-docker-jobs.yml
@@ -4,7 +4,7 @@
 parameters:
 - name: targetOsArch    # example: debian9_arm32
   type: string
-- name: version
+- name: imageVersion
   type: string
 - name: stepsTemplate   # example: dopapt-docker-steps.yml
   type: string

--- a/azure-pipelines/build/templates/do-docker-jobs.yml
+++ b/azure-pipelines/build/templates/do-docker-jobs.yml
@@ -4,6 +4,8 @@
 parameters:
 - name: targetOsArch    # example: debian9_arm32
   type: string
+- name: version
+  type: string
 - name: stepsTemplate   # example: dopapt-docker-steps.yml
   type: string
 
@@ -13,6 +15,7 @@ jobs:
   - template: ${{parameters.stepsTemplate}}
     parameters:
       targetOsArch: ${{parameters.targetOsArch}}
+      version: ${{parameters.version}}
       config: debug
 
 - job: ${{parameters.targetOsArch}}_release
@@ -20,4 +23,5 @@ jobs:
   - template: ${{parameters.stepsTemplate}}
     parameters:
       targetOsArch: ${{parameters.targetOsArch}}
+      version: ${{parameters.version}}
       config: minsizerel

--- a/azure-pipelines/build/templates/do-docker-jobs.yml
+++ b/azure-pipelines/build/templates/do-docker-jobs.yml
@@ -15,7 +15,7 @@ jobs:
   - template: ${{parameters.stepsTemplate}}
     parameters:
       targetOsArch: ${{parameters.targetOsArch}}
-      version: ${{parameters.version}}
+      version: ${{parameters.imageVersion}}
       config: debug
 
 - job: ${{parameters.targetOsArch}}_release
@@ -23,5 +23,5 @@ jobs:
   - template: ${{parameters.stepsTemplate}}
     parameters:
       targetOsArch: ${{parameters.targetOsArch}}
-      version: ${{parameters.version}}
+      version: ${{parameters.imageVersion}}
       config: minsizerel

--- a/azure-pipelines/build/templates/doclient-lite-docker-steps.yml
+++ b/azure-pipelines/build/templates/doclient-lite-docker-steps.yml
@@ -26,7 +26,7 @@ steps:
 
 - task: CmdLine@2
   inputs:
-    script: 'sudo docker run --rm --entrypoint=python3 -v $(Build.SourcesDirectory):/code -v /tmp/build-deliveryoptimization-agent-${{parameters.targetOsArch}}:/tmp/build-deliveryoptimization-agent doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:latest "/code/build/build.py" "--clean" "--package-for" "DEB" "--config" "${{parameters.config}}" "--project" "agent"'
+    script: 'sudo docker run --rm --entrypoint=python3 -v $(Build.SourcesDirectory):/code -v /tmp/build-deliveryoptimization-agent-${{parameters.targetOsArch}}:/tmp/build-deliveryoptimization-agent doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.version}} "/code/build/build.py" "--clean" "--package-for" "DEB" "--config" "${{parameters.config}}" "--project" "agent"'
   displayName: 'Build client-lite ${{parameters.targetOsArch}}-${{parameters.config}}'
 
 - task: CopyFiles@2

--- a/azure-pipelines/build/templates/doclient-lite-docker-steps.yml
+++ b/azure-pipelines/build/templates/doclient-lite-docker-steps.yml
@@ -15,7 +15,7 @@ steps:
   inputs:
     command: login
     containerRegistry: doclientcontainerregistry
-    repository: $(parameters.targetOsArch)_$(parameters.version)
+    repository: $(parameters.targetOsArch)
 
 - task: Docker@2
   displayName: Pull latest build image

--- a/azure-pipelines/build/templates/doclient-lite-docker-steps.yml
+++ b/azure-pipelines/build/templates/doclient-lite-docker-steps.yml
@@ -4,7 +4,7 @@
 parameters:
 - name: targetOsArch    # example: debian9_arm32
   type: string
-- name: version
+- name: imageVersion
   type: string
 - name: config          # debug/release/minsizerel/relwithdebuginfo
   type: string

--- a/azure-pipelines/build/templates/doclient-lite-docker-steps.yml
+++ b/azure-pipelines/build/templates/doclient-lite-docker-steps.yml
@@ -22,11 +22,11 @@ steps:
   inputs:
     command: pull
     containerRegistry: doclientcontainerregistry
-    arguments: 'doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.version}}'
+    arguments: 'doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.imageVersion}}'
 
 - task: CmdLine@2
   inputs:
-    script: 'sudo docker run --rm --entrypoint=python3 -v $(Build.SourcesDirectory):/code -v /tmp/build-deliveryoptimization-agent-${{parameters.targetOsArch}}:/tmp/build-deliveryoptimization-agent doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.version}} "/code/build/build.py" "--clean" "--package-for" "DEB" "--config" "${{parameters.config}}" "--project" "agent"'
+    script: 'sudo docker run --rm --entrypoint=python3 -v $(Build.SourcesDirectory):/code -v /tmp/build-deliveryoptimization-agent-${{parameters.targetOsArch}}:/tmp/build-deliveryoptimization-agent doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.imageVersion}} "/code/build/build.py" "--clean" "--package-for" "DEB" "--config" "${{parameters.config}}" "--project" "agent"'
   displayName: 'Build client-lite ${{parameters.targetOsArch}}-${{parameters.config}}'
 
 - task: CopyFiles@2

--- a/azure-pipelines/build/templates/doclient-lite-docker-steps.yml
+++ b/azure-pipelines/build/templates/doclient-lite-docker-steps.yml
@@ -15,14 +15,14 @@ steps:
   inputs:
     command: login
     containerRegistry: doclientcontainerregistry
-    repository: $(parameters.targetOsArch)-$(parameters.version)
+    repository: $(parameters.targetOsArch)_$(parameters.version)
 
 - task: Docker@2
   displayName: Pull latest build image
   inputs:
     command: pull
     containerRegistry: doclientcontainerregistry
-    arguments: 'doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}-${{parameters.version}}:latest'
+    arguments: 'doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}_${{parameters.version}}:latest'
 
 - task: CmdLine@2
   inputs:

--- a/azure-pipelines/build/templates/doclient-lite-docker-steps.yml
+++ b/azure-pipelines/build/templates/doclient-lite-docker-steps.yml
@@ -4,6 +4,8 @@
 parameters:
 - name: targetOsArch    # example: debian9_arm32
   type: string
+- name: version
+  type: string
 - name: config          # debug/release/minsizerel/relwithdebuginfo
   type: string
 
@@ -13,14 +15,14 @@ steps:
   inputs:
     command: login
     containerRegistry: doclientcontainerregistry
-    repository: $(parameters.targetOsArch)
+    repository: $(parameters.targetOsArch)-$(parameters.version)
 
 - task: Docker@2
   displayName: Pull latest build image
   inputs:
     command: pull
     containerRegistry: doclientcontainerregistry
-    arguments: 'doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:latest'
+    arguments: 'doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}-${{parameters.version}}:latest'
 
 - task: CmdLine@2
   inputs:

--- a/azure-pipelines/build/templates/doclient-lite-docker-steps.yml
+++ b/azure-pipelines/build/templates/doclient-lite-docker-steps.yml
@@ -22,7 +22,7 @@ steps:
   inputs:
     command: pull
     containerRegistry: doclientcontainerregistry
-    arguments: 'doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}_${{parameters.version}}:latest'
+    arguments: 'doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.version}}'
 
 - task: CmdLine@2
   inputs:

--- a/azure-pipelines/build/templates/doclient-lite-native-steps.yml
+++ b/azure-pipelines/build/templates/doclient-lite-native-steps.yml
@@ -11,12 +11,6 @@ parameters:
   default: false
 
 steps:
-- task: CmdLine@2
-  inputs:
-    script: 'sudo apt-get install -y libcurl4-openssl-dev'
-    workingDirectory: '$(Build.SourcesDirectory)/build'
-  displayName: 'Build agent ${{parameters.targetOsArch}}-${{parameters.config}}'
-
 # Have to use cmdline rather than built in python task, because the python env variable chooses python2
 # There is a pipeline task which allows you to specify version, but that requires configuring of the agent tools directory
 - task: CmdLine@2

--- a/azure-pipelines/build/templates/doclient-lite-native-steps.yml
+++ b/azure-pipelines/build/templates/doclient-lite-native-steps.yml
@@ -11,6 +11,12 @@ parameters:
   default: false
 
 steps:
+- task: CmdLine@2
+  inputs:
+    script: 'sudo apt-get install -y libcurl4-openssl-dev'
+    workingDirectory: '$(Build.SourcesDirectory)/build'
+  displayName: 'Build agent ${{parameters.targetOsArch}}-${{parameters.config}}'
+
 # Have to use cmdline rather than built in python task, because the python env variable chooses python2
 # There is a pipeline task which allows you to specify version, but that requires configuring of the agent tools directory
 - task: CmdLine@2

--- a/azure-pipelines/build/templates/dopapt-docker-steps.yml
+++ b/azure-pipelines/build/templates/dopapt-docker-steps.yml
@@ -24,11 +24,11 @@ steps:
   inputs:
     command: pull
     containerRegistry: doclientcontainerregistry
-    arguments: 'doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.version}}'
+    arguments: 'doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.imageVersion}}'
 
 - task: CmdLine@2
   inputs:
-    script: 'sudo docker run --rm --entrypoint=/bin/bash -v $(Build.SourcesDirectory):/code -v /tmp/build-deliveryoptimization-plugin-apt-${{parameters.targetOsArch}}:/tmp/build-deliveryoptimization-plugin-apt doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.version}} "/code/build/docker/docker-build-plugin.sh" "/code" "${{parameters.config}}"'
+    script: 'sudo docker run --rm --entrypoint=/bin/bash -v $(Build.SourcesDirectory):/code -v /tmp/build-deliveryoptimization-plugin-apt-${{parameters.targetOsArch}}:/tmp/build-deliveryoptimization-plugin-apt doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.imageVersion}} "/code/build/docker/docker-build-plugin.sh" "/code" "${{parameters.config}}"'
   displayName: 'Build deliveryoptimization-plugin-apt ${{parameters.targetOsArch}}-${{parameters.config}}'
 
 - task: CopyFiles@2

--- a/azure-pipelines/build/templates/dopapt-docker-steps.yml
+++ b/azure-pipelines/build/templates/dopapt-docker-steps.yml
@@ -4,7 +4,7 @@
 parameters:
 - name: targetOsArch    # example: debian9_arm32
   type: string
-- name: version
+- name: imageVersion
   type: string
 - name: config          # debug/release/minsizerel/relwithdebuginfo
   type: string

--- a/azure-pipelines/build/templates/dopapt-docker-steps.yml
+++ b/azure-pipelines/build/templates/dopapt-docker-steps.yml
@@ -17,14 +17,14 @@ steps:
   inputs:
     command: login
     containerRegistry: doclientcontainerregistry
-    repository: $(parameters.targetOsArch)-$(parameters.version)
+    repository: $(parameters.targetOsArch)_$(parameters.version)
 
 - task: Docker@2
   displayName: Pull latest build image
   inputs:
     command: pull
     containerRegistry: doclientcontainerregistry
-    arguments: 'doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}-${{parameters-version}}:latest'
+    arguments: 'doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}_${{parameters-version}}:latest'
 
 - task: CmdLine@2
   inputs:

--- a/azure-pipelines/build/templates/dopapt-docker-steps.yml
+++ b/azure-pipelines/build/templates/dopapt-docker-steps.yml
@@ -24,7 +24,7 @@ steps:
   inputs:
     command: pull
     containerRegistry: doclientcontainerregistry
-    arguments: 'doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}_${{parameters-version}}:latest'
+    arguments: 'doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters-version}}'
 
 - task: CmdLine@2
   inputs:

--- a/azure-pipelines/build/templates/dopapt-docker-steps.yml
+++ b/azure-pipelines/build/templates/dopapt-docker-steps.yml
@@ -17,7 +17,7 @@ steps:
   inputs:
     command: login
     containerRegistry: doclientcontainerregistry
-    repository: $(parameters.targetOsArch)_$(parameters.version)
+    repository: $(parameters.targetOsArch)
 
 - task: Docker@2
   displayName: Pull latest build image

--- a/azure-pipelines/build/templates/dopapt-docker-steps.yml
+++ b/azure-pipelines/build/templates/dopapt-docker-steps.yml
@@ -24,7 +24,7 @@ steps:
   inputs:
     command: pull
     containerRegistry: doclientcontainerregistry
-    arguments: 'doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters-version}}'
+    arguments: 'doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.version}}'
 
 - task: CmdLine@2
   inputs:

--- a/azure-pipelines/build/templates/dopapt-docker-steps.yml
+++ b/azure-pipelines/build/templates/dopapt-docker-steps.yml
@@ -28,7 +28,7 @@ steps:
 
 - task: CmdLine@2
   inputs:
-    script: 'sudo docker run --rm --entrypoint=/bin/bash -v $(Build.SourcesDirectory):/code -v /tmp/build-deliveryoptimization-plugin-apt-${{parameters.targetOsArch}}:/tmp/build-deliveryoptimization-plugin-apt doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:latest "/code/build/docker/docker-build-plugin.sh" "/code" "${{parameters.config}}"'
+    script: 'sudo docker run --rm --entrypoint=/bin/bash -v $(Build.SourcesDirectory):/code -v /tmp/build-deliveryoptimization-plugin-apt-${{parameters.targetOsArch}}:/tmp/build-deliveryoptimization-plugin-apt doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.version}} "/code/build/docker/docker-build-plugin.sh" "/code" "${{parameters.config}}"'
   displayName: 'Build deliveryoptimization-plugin-apt ${{parameters.targetOsArch}}-${{parameters.config}}'
 
 - task: CopyFiles@2

--- a/azure-pipelines/build/templates/dopapt-docker-steps.yml
+++ b/azure-pipelines/build/templates/dopapt-docker-steps.yml
@@ -4,6 +4,8 @@
 parameters:
 - name: targetOsArch    # example: debian9_arm32
   type: string
+- name: version
+  type: string
 - name: config          # debug/release/minsizerel/relwithdebuginfo
   type: string
 
@@ -15,14 +17,14 @@ steps:
   inputs:
     command: login
     containerRegistry: doclientcontainerregistry
-    repository: $(parameters.targetOsArch)
+    repository: $(parameters.targetOsArch)-$(parameters.version)
 
 - task: Docker@2
   displayName: Pull latest build image
   inputs:
     command: pull
     containerRegistry: doclientcontainerregistry
-    arguments: 'doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:latest'
+    arguments: 'doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}-${{parameters-version}}:latest'
 
 - task: CmdLine@2
   inputs:

--- a/azure-pipelines/build/templates/dosdkcpp-docker-steps.yml
+++ b/azure-pipelines/build/templates/dosdkcpp-docker-steps.yml
@@ -26,7 +26,7 @@ steps:
 
 - task: CmdLine@2
   inputs:
-    script: 'sudo docker run --rm --entrypoint=python3 -v $(Build.SourcesDirectory):/code -v /tmp/build-deliveryoptimization-sdk-${{parameters.targetOsArch}}:/tmp/build-deliveryoptimization-sdk doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:latest "/code/build/build.py" "--clean" "--package-for" "DEB" "--config" "${{parameters.config}}" "--project" "sdk" "--cmaketarget" "deliveryoptimization"'
+    script: 'sudo docker run --rm --entrypoint=python3 -v $(Build.SourcesDirectory):/code -v /tmp/build-deliveryoptimization-sdk-${{parameters.targetOsArch}}:/tmp/build-deliveryoptimization-sdk doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.version}} "/code/build/build.py" "--clean" "--package-for" "DEB" "--config" "${{parameters.config}}" "--project" "sdk" "--cmaketarget" "deliveryoptimization"'
   displayName: 'Build sdk-cpp ${{parameters.targetOsArch}}-${{parameters.config}}'
 
 - task: CopyFiles@2

--- a/azure-pipelines/build/templates/dosdkcpp-docker-steps.yml
+++ b/azure-pipelines/build/templates/dosdkcpp-docker-steps.yml
@@ -4,6 +4,8 @@
 parameters:
 - name: targetOsArch    # example: debian9_arm32
   type: string
+- name: version
+  type: string
 - name: config          # debug/release
   type: string
 
@@ -13,14 +15,14 @@ steps:
   inputs:
     command: login
     containerRegistry: doclientcontainerregistry
-    repository: $(parameters.targetOsArch)
+    repository: $(parameters.targetOsArch)-$(parameters.version)
 
 - task: Docker@2
   displayName: Pull latest build image
   inputs:
     command: pull
     containerRegistry: doclientcontainerregistry
-    arguments: 'doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:latest'
+    arguments: 'doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}-${{version}}:latest'
 
 - task: CmdLine@2
   inputs:

--- a/azure-pipelines/build/templates/dosdkcpp-docker-steps.yml
+++ b/azure-pipelines/build/templates/dosdkcpp-docker-steps.yml
@@ -15,7 +15,7 @@ steps:
   inputs:
     command: login
     containerRegistry: doclientcontainerregistry
-    repository: $(parameters.targetOsArch)_$(parameters.version)
+    repository: $(parameters.targetOsArch)
 
 - task: Docker@2
   displayName: Pull latest build image

--- a/azure-pipelines/build/templates/dosdkcpp-docker-steps.yml
+++ b/azure-pipelines/build/templates/dosdkcpp-docker-steps.yml
@@ -22,11 +22,11 @@ steps:
   inputs:
     command: pull
     containerRegistry: doclientcontainerregistry
-    arguments: 'doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.version}}'
+    arguments: 'doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.imageVersion}}'
 
 - task: CmdLine@2
   inputs:
-    script: 'sudo docker run --rm --entrypoint=python3 -v $(Build.SourcesDirectory):/code -v /tmp/build-deliveryoptimization-sdk-${{parameters.targetOsArch}}:/tmp/build-deliveryoptimization-sdk doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.version}} "/code/build/build.py" "--clean" "--package-for" "DEB" "--config" "${{parameters.config}}" "--project" "sdk" "--cmaketarget" "deliveryoptimization"'
+    script: 'sudo docker run --rm --entrypoint=python3 -v $(Build.SourcesDirectory):/code -v /tmp/build-deliveryoptimization-sdk-${{parameters.targetOsArch}}:/tmp/build-deliveryoptimization-sdk doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.imageVersion}} "/code/build/build.py" "--clean" "--package-for" "DEB" "--config" "${{parameters.config}}" "--project" "sdk" "--cmaketarget" "deliveryoptimization"'
   displayName: 'Build sdk-cpp ${{parameters.targetOsArch}}-${{parameters.config}}'
 
 - task: CopyFiles@2

--- a/azure-pipelines/build/templates/dosdkcpp-docker-steps.yml
+++ b/azure-pipelines/build/templates/dosdkcpp-docker-steps.yml
@@ -22,7 +22,7 @@ steps:
   inputs:
     command: pull
     containerRegistry: doclientcontainerregistry
-    arguments: 'doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{version}}'
+    arguments: 'doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.version}}'
 
 - task: CmdLine@2
   inputs:

--- a/azure-pipelines/build/templates/dosdkcpp-docker-steps.yml
+++ b/azure-pipelines/build/templates/dosdkcpp-docker-steps.yml
@@ -4,7 +4,7 @@
 parameters:
 - name: targetOsArch    # example: debian9_arm32
   type: string
-- name: version
+- name: imageVersion
   type: string
 - name: config          # debug/release
   type: string

--- a/azure-pipelines/build/templates/dosdkcpp-docker-steps.yml
+++ b/azure-pipelines/build/templates/dosdkcpp-docker-steps.yml
@@ -15,14 +15,14 @@ steps:
   inputs:
     command: login
     containerRegistry: doclientcontainerregistry
-    repository: $(parameters.targetOsArch)-$(parameters.version)
+    repository: $(parameters.targetOsArch)_$(parameters.version)
 
 - task: Docker@2
   displayName: Pull latest build image
   inputs:
     command: pull
     containerRegistry: doclientcontainerregistry
-    arguments: 'doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}-${{version}}:latest'
+    arguments: 'doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}_${{version}}:latest'
 
 - task: CmdLine@2
   inputs:

--- a/azure-pipelines/build/templates/dosdkcpp-docker-steps.yml
+++ b/azure-pipelines/build/templates/dosdkcpp-docker-steps.yml
@@ -22,7 +22,7 @@ steps:
   inputs:
     command: pull
     containerRegistry: doclientcontainerregistry
-    arguments: 'doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}_${{version}}:latest'
+    arguments: 'doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{version}}'
 
 - task: CmdLine@2
   inputs:

--- a/build/bootstrap.sh
+++ b/build/bootstrap.sh
@@ -65,7 +65,7 @@ function installBuildDependencies
     fi
 
     echo "[INFO] Installing build dependencies"
-    apt-get install -y make build-essential g++ gdb gdbserver gcc git wget
+    apt-get install -y cmake make build-essential g++ gdb gdbserver gcc git wget
     apt-get install -y python3 ninja-build
 
     if [[ "$PLATFORM" == "debian9" ]];
@@ -79,7 +79,7 @@ function installBuildDependencies
         make
         make install
     else
-        apt-get -y install cmake libmsgsl-dev
+        apt-get -y install libmsgsl-dev
     fi
 
     apt-get install -y libboost-system-dev libboost-filesystem-dev libboost-program-options-dev


### PR DESCRIPTION
- Docker build containers now support specifying version. This version aligns with the next github release version in semantic versioning format.
- Also specify vmImage name as the host machine needs to be patched to use libcurl instead of cpprest.