### PR TITLE
[Draft] Remove internal exceptions & Expose non-throwing apis

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -81,6 +81,12 @@ class ArgParserBase(object):
             help='Override default build output directory'
         )
 
+        '''SDK only'''
+        self.parser.add_argument(
+            '--disable-exceptions', dest='disable_exceptions', action='store_true',
+            help='Builds libdeliveryoptimization without compiling exception throwing code into the binary'
+        )
+
     def parse(self):
         return self.parser.parse_args()
 
@@ -171,6 +177,8 @@ class BuildRunnerBase(object):
             self.generator = self.script_args.generator
 
         self.skip_tests = script_args.skip_tests
+
+        self.disable_exceptions = script_args.disable_exceptions
 
         self.source_path = self.project_root_path
 
@@ -360,6 +368,9 @@ class BuildRunnerBase(object):
 
         if self.skip_tests:
             generate_options.extend(["-DDO_BUILD_TESTS=OFF"])
+
+        if self.disable_exceptions:
+            generate_options.extend(["-DDO_DISABLE_EXCEPTIONS=ON"])
 
         if self.project:
             generate_options.extend([DOCLIENT_SUBPROJECT_BUILD_MAP[self.project]])

--- a/sdk-cpp/CMakeLists.txt
+++ b/sdk-cpp/CMakeLists.txt
@@ -45,7 +45,6 @@ if(DO_PLATFORM_LINUX)
     )
 
     add_library(${DO_SDK_LIB_NAME} SHARED "${sdk_source}")
-
     set(sdk_compile_definitions
         DOSVC_BIN_NAME="${DOSVC_BIN_NAME}"
         DO_PLUGIN_APT_BIN_NAME="${DO_PLUGIN_APT_BIN_NAME}"
@@ -121,6 +120,9 @@ target_compile_definitions(${DO_SDK_LIB_NAME}
 if (DO_DEV_DEBUG)
     target_compile_definitions(${DO_SDK_LIB_NAME} PRIVATE DO_DEV_DEBUG)
 endif ()
+if (DO_DISABLE_EXCEPTIONS)
+    target_compile_definitions(${DO_SDK_LIB_NAME} PRIVATE DO_DISABLE_EXCEPTIONS)
+endif()
 add_platform_interface_definitions(${DO_SDK_LIB_NAME})
 
 target_link_libraries(${DO_SDK_LIB_NAME}

--- a/sdk-cpp/include/do_download.h
+++ b/sdk-cpp/include/do_download.h
@@ -26,46 +26,43 @@ public:
     download(const std::string& uri, const std::string& downloadFilePath);
     ~download();
 
+#if (!DO_DISABLE_EXCEPTIONS)
     void start();
     void pause();
     void resume();
     void finalize();
     void abort();
-
     download_status get_status() const;
 
     void start_and_wait_until_completion(std::chrono::seconds timeoutSecs = std::chrono::hours(24));
     void start_and_wait_until_completion(const std::atomic_bool& isCancelled, std::chrono::seconds timeoutSecs = std::chrono::hours(24));
-
     static void download_url_to_path(const std::string& uri, const std::string& downloadFilePath, std::chrono::seconds timeoutSecs = std::chrono::hours(24));
     static void download_url_to_path(const std::string& uri, const std::string& downloadFilePath, const std::atomic_bool& isCancelled, std::chrono::seconds timeoutSecs = std::chrono::hours(24));
+#endif
+
+    int32_t start_nothrow();
+    int32_t pause_nothrow();
+    int32_t resume_nothrow();
+    int32_t finalize_nothrow();
+    int32_t abort_nothrow();
+    int32_t get_status_nothrow(download_status& status);
+
+    int32_t start_and_wait_until_completion_nothrow(std::chrono::seconds timeoutSecs = std::chrono::hours(24));
+    int32_t start_and_wait_until_completion_nothrow(const std::atomic_bool& isCancelled, std::chrono::seconds timeoutSecs = std::chrono::hours(24));
+    static int32_t download_url_to_path_nothrow(const std::string& uri, const std::string& downloadFilePath, std::chrono::seconds timeoutSecs = std::chrono::hours(24));
+    static int32_t download_url_to_path_nothrow(const std::string& uri, const std::string& downloadFilePath, const std::atomic_bool& isCancelled, std::chrono::seconds timeoutSecs = std::chrono::hours(24));
 
 #if defined(DO_INTERFACE_COM)
-    /* Sets a download property for the current download object
-    This function attempts to set a download property using the caller-supplied value. This method can throw
-    ~~~~
+    /*
     For devices running windows before 20H1, dosvc exposed a now-deprecated com interface for setting certain download properties.
     After 20H1, these properties were added to newer com interface, which this SDK is using.
     Attempting to set a download property on a version of windows earlier than 20H1 will not set the property and throw an exception with error code msdo::errc::do_e_unknown_property_id
-    ~~~~
-    @param key, enum class defined in do_download_property.h that defines which property to set
-    @param value, the download_property_value to set
     */
+#if (!DO_DISABLE_EXCEPTIONS)
     void set_property(download_property key, const download_property_value& value);
-
-    /* Same as set_property() but exceptions are handled internally and returned as an int32_t error code
-    ~~~~
-    @param key, enum class defined in do_download_property.h that defines which property to set
-    @param value, the download_property_value to set
-    @returns int32_t error code value, 0 on success, int32_t error code corresponding to the error otherwise.
-    */
+#endif
     int32_t set_property_nothrow(download_property key, const download_property_value& value) noexcept;
 
-    /* Gets the value for the specified download_property key for the current download object
-    ~~~~
-    @param key, the desired download_property to retrieve for this download object
-    @returns the download_property_value corresponding to the supplied key
-    */
     download_property_value get_property(download_property key);
 #endif
 

--- a/sdk-cpp/include/do_download_property.h
+++ b/sdk-cpp/include/do_download_property.h
@@ -3,6 +3,7 @@
 
 //TODO(jimson): Callers may not have defined these compile definitions, as a result their builds may fail if the definition is not set when using the SDK
 //Look into removing platform specific header files from the SDK installation
+//For this specific header, we will need to support it on the rest interface anyways so we will be removing the ifdef
 #if defined(DO_INTERFACE_COM)
 
 #include <OAIdl.h>

--- a/sdk-cpp/include/do_exceptions.h
+++ b/sdk-cpp/include/do_exceptions.h
@@ -1,21 +1,46 @@
 #ifndef _DELIVERY_OPTIMIZATION_DO_EXCEPTIONS_H
 #define _DELIVERY_OPTIMIZATION_DO_EXCEPTIONS_H
 
+#if (!DO_DISABLE_EXCEPTIONS)
+
 #include <exception>
 #include <stdint.h>
 #include <system_error>
 
-#if defined(DO_INTERFACE_COM)
-#include <winerror.h>   // FAILED macro
-#endif
+#endif // !DO_DISABLE_EXCEPTIONS
 
 namespace microsoft
 {
 namespace deliveryoptimization
 {
 
+// Error Macros
+#ifndef RETURN_HR_IF_FAILED
+#define RETURN_HR_IF_FAILED(hr)  {  \
+    int32_t __hr = (hr);            \
+    if(FAILED(__hr)) return __hr;   \
+}
+#endif
+
+#ifndef FACILITY_DELIVERY_OPTIMIZATION 
+#define FACILITY_DELIVERY_OPTIMIZATION   208
+#endif
+
+#define HRESULT_FROM_SYSTEM_ERROR(x) ((int32_t)(x) <= 0 ? ((int32_t)(x)) : ((int32_t) (((x) & 0x0000FFFF) | (FACILITY_DELIVERY_OPTIMIZATION << 16) | 0x80000000)))
+
+#ifndef FAILED
+#define FAILED(hr) (((int32_t)(hr)) < 0)
+#endif
+
+#ifndef SUCCEEDED
+#define SUCCEEDED(hr) (((int32_t)(hr)) >= 0)
+#endif
+
+#if (!DO_DISABLE_EXCEPTIONS)
+
 enum class errc : int32_t
 {
+    ok                          = 0,
     unexpected                  = -2147418113,
     invalid_arg                 = -2147024809,
     not_found                   = -2147023728,
@@ -51,8 +76,6 @@ private:
     std::string _msg;
 };
 
-#if defined(DO_INTERFACE_COM)
-//TODO: Look into replacing using internal exception class
 inline void throw_if_fail(int32_t hr)
 {
     if (FAILED(hr))
@@ -60,8 +83,8 @@ inline void throw_if_fail(int32_t hr)
         throw exception(hr);
     }
 }
-#endif
+#endif // !DO_DISABLE_EXCEPTIONS
+}
+}
 
-}
-}
 #endif

--- a/sdk-cpp/src/do_config.cpp
+++ b/sdk-cpp/src/do_config.cpp
@@ -80,7 +80,9 @@ static std::string GetBinaryVersion(const boost::filesystem::path& binaryFilePat
             fp = popen(command.c_str(), "r");
             if (fp == nullptr)
             {
+#if !defined(DO_DISABLE_EXCEPTIONS)
                 throw std::exception();
+#endif
             }
 
             char readBuffer[256];

--- a/sdk-cpp/src/do_exceptions.cpp
+++ b/sdk-cpp/src/do_exceptions.cpp
@@ -1,3 +1,4 @@
+#if (!DO_DISABLE_EXCEPTIONS)
 
 #include "do_exceptions.h"
 
@@ -58,3 +59,5 @@ const std::error_code& exception::get_error_code() const
 
 } // namespace deliveryoptimization
 } // namespace microsoft
+
+#endif //!DO_DISABLE_EXCEPTIONS

--- a/sdk-cpp/src/internal/com/download_impl.cpp
+++ b/sdk-cpp/src/internal/com/download_impl.cpp
@@ -59,97 +59,118 @@ static msdo::download_status ConvertFromComStatus(const DO_DOWNLOAD_STATUS& plat
         platformStatus.ExtendedError, ConvertFromComState(platformStatus.State));
 }
 
-static DODownloadProperty ConvertToComProperty(msdo::download_property key)
+static int32_t ConvertToComProperty(msdo::download_property key, DODownloadProperty& comProperty)
 {
     switch (key)
     {
     case msdo::download_property::blocking_mode:
     {
-        return DODownloadProperty_BlockingMode;
+        comProperty = DODownloadProperty_BlockingMode;
+        return S_OK;
     }
     case msdo::download_property::callback_interface:
     {
-        return DODownloadProperty_CallbackInterface;
+        comProperty = DODownloadProperty_CallbackInterface;
+        return S_OK;
     }
     case msdo::download_property::disallow_on_cellular:
     {
-        return DODownloadProperty_DisallowOnCellular;
+        comProperty = DODownloadProperty_DisallowOnCellular;
+        return S_OK;
     }
     case msdo::download_property::caller_name:
     {
-        return DODownloadProperty_DisplayName;
+        comProperty = DODownloadProperty_DisplayName;
+        return S_OK;
     }
     case msdo::download_property::catalog_id:
     {
-        return DODownloadProperty_ContentId;
+        comProperty = DODownloadProperty_ContentId;
+        return S_OK;
     }
     case msdo::download_property::correlation_vector:
     {
-        return DODownloadProperty_CorrelationVector;
+        comProperty = DODownloadProperty_CorrelationVector;
+        return S_OK;
     }
     case msdo::download_property::cost_policy:
     {
-        return DODownloadProperty_CostPolicy;
+        comProperty = DODownloadProperty_CostPolicy;
+        return S_OK;
     }
     case msdo::download_property::decryption_info:
     {
-        return DODownloadProperty_DecryptionInfo;
+        comProperty = DODownloadProperty_DecryptionInfo;
+        return S_OK;
     }
     case msdo::download_property::download_file_path:
     {
-        return DODownloadProperty_LocalPath;
+        comProperty = DODownloadProperty_LocalPath;
+        return S_OK;
     }
     case msdo::download_property::http_custom_auth_headers:
     {
-        return DODownloadProperty::DODownloadProperty_HttpCustomAuthHeaders;
+        comProperty = DODownloadProperty::DODownloadProperty_HttpCustomAuthHeaders;
+        return S_OK;
     }
     case msdo::download_property::http_custom_headers:
     {
-        return DODownloadProperty_HttpCustomHeaders;
+        comProperty = DODownloadProperty_HttpCustomHeaders;
+        return S_OK;
     }
     case msdo::download_property::id:
     {
-        return DODownloadProperty_Id;
+        comProperty = DODownloadProperty_Id;
+        return S_OK;
     }
     case msdo::download_property::integrity_check_info:
     {
-        return DODownloadProperty_IntegrityCheckInfo;
+        comProperty = DODownloadProperty_IntegrityCheckInfo;
+        return S_OK;
     }
     case msdo::download_property::integrity_check_mandatory:
     {
-        return DODownloadProperty_IntegrityCheckMandatory;
+        comProperty = DODownloadProperty_IntegrityCheckMandatory;
+        return S_OK;
     }
     case msdo::download_property::network_token:
     {
-        return DODownloadProperty_NetworkToken;
+        comProperty = DODownloadProperty_NetworkToken;
+        return S_OK;
     }
     case msdo::download_property::no_progress_timeout_seconds:
     {
-        return DODownloadProperty_NoProgressTimeoutSeconds;
+        comProperty = DODownloadProperty_NoProgressTimeoutSeconds;
+        return S_OK;
     }
     case msdo::download_property::stream_interface:
     {
-        return DODownloadProperty_StreamInterface;
+        comProperty = DODownloadProperty_StreamInterface;
+        return S_OK;
     }
     case msdo::download_property::security_context:
     {
-        return DODownloadProperty_SecurityContext;
+        comProperty = DODownloadProperty_SecurityContext;
+        return S_OK;
     }
     case msdo::download_property::total_size_bytes:
     {
-        return DODownloadProperty_TotalSizeBytes;
+        comProperty = DODownloadProperty_TotalSizeBytes;
+        return S_OK;
     }
     case msdo::download_property::uri:
     {
-        return DODownloadProperty_Uri;
+        comProperty = DODownloadProperty_Uri;
+        return S_OK;
     }
     case msdo::download_property::use_foreground_priority:
     {
-        return DODownloadProperty_ForegroundPriority;
+        comProperty = DODownloadProperty_ForegroundPriority;
+        return S_OK;
     }
     default:
     {
-        throw E_INVALIDARG;
+        return E_INVALIDARG;
     }
     }
 }
@@ -195,100 +216,116 @@ private:
 
 CDownloadImpl::CDownloadImpl(const std::string& uri, const std::string& downloadFilePath)
 {
+    _codeInit = _Initialize(uri, downloadFilePath);
+}
+
+
+int32_t CDownloadImpl::_Initialize(const std::string& uri, const std::string& downloadFilePath)
+{
     Microsoft::WRL::ComPtr<IDOManager> manager;
-    throw_if_fail(CoCreateInstance(__uuidof(DeliveryOptimization), nullptr, CLSCTX_LOCAL_SERVER, IID_PPV_ARGS(&manager)));
+    RETURN_HR_IF_FAILED(CoCreateInstance(__uuidof(DeliveryOptimization), nullptr, CLSCTX_LOCAL_SERVER, IID_PPV_ARGS(&manager)));
     Microsoft::WRL::ComPtr<IDODownload> spDownload;
-    throw_if_fail(manager->CreateDownload(&spDownload));
+    RETURN_HR_IF_FAILED(manager->CreateDownload(&spDownload));
 
-    try {
-        throw_if_fail(CoSetProxyBlanket(static_cast<IUnknown*>(spDownload.Get()), RPC_C_AUTHN_DEFAULT,
-            RPC_C_AUTHZ_NONE, COLE_DEFAULT_PRINCIPAL, RPC_C_AUTHN_LEVEL_DEFAULT, RPC_C_IMP_LEVEL_IMPERSONATE,
-            nullptr, EOAC_STATIC_CLOAKING));
+    RETURN_HR_IF_FAILED(CoSetProxyBlanket(static_cast<IUnknown*>(spDownload.Get()), RPC_C_AUTHN_DEFAULT,
+        RPC_C_AUTHZ_NONE, COLE_DEFAULT_PRINCIPAL, RPC_C_AUTHN_LEVEL_DEFAULT, RPC_C_IMP_LEVEL_IMPERSONATE,
+        nullptr, EOAC_STATIC_CLOAKING));
 
-        download_property_value propUri(uri);
-        download_property_value propDownloadFilePath(downloadFilePath);
+    download_property_value propUri(uri);
+    download_property_value propDownloadFilePath(downloadFilePath);
 
-        _SetPropertyHelper(*spDownload.Get(), download_property::uri, propUri);
-        _SetPropertyHelper(*spDownload.Get(), download_property::download_file_path, propDownloadFilePath);
-    }
-    catch (const exception& e)
-    {
-        spDownload->Abort();
-        throw e;
-    }
+    RETURN_HR_IF_FAILED(_SetPropertyHelper(*spDownload.Get(), download_property::uri, propUri));
+    RETURN_HR_IF_FAILED(_SetPropertyHelper(*spDownload.Get(), download_property::download_file_path, propDownloadFilePath));
+
     _spDownload = std::move(spDownload);
+    return 0;
 }
 
 // Support only full file downloads for now
-void CDownloadImpl::Start()
+int32_t CDownloadImpl::Start()
 {
+    RETURN_HR_IF_FAILED(_codeInit);
     _DO_DOWNLOAD_RANGES_INFO emptyRanges = {};
     emptyRanges.RangeCount = 0;
-    throw_if_fail(_spDownload->Start(&emptyRanges));
+    return _spDownload->Start(&emptyRanges);
 }
 
-void CDownloadImpl::Pause()
+int32_t CDownloadImpl::Pause()
 {
-    throw_if_fail(_spDownload->Pause());
+    RETURN_HR_IF_FAILED(_codeInit);
+    return _spDownload->Pause();
 }
 
-void CDownloadImpl::Resume()
+int32_t CDownloadImpl::Resume()
 {
-    throw_if_fail(_spDownload->Start(nullptr));
+    RETURN_HR_IF_FAILED(_codeInit);
+    return _spDownload->Start(nullptr);
 }
 
-void CDownloadImpl::Finalize()
+int32_t CDownloadImpl::Finalize()
 {
-    throw_if_fail(_spDownload->Finalize());
+    RETURN_HR_IF_FAILED(_codeInit);
+    return _spDownload->Finalize();
 }
 
-void CDownloadImpl::Abort()
+int32_t CDownloadImpl::Abort()
 {
-    throw_if_fail(_spDownload->Abort());
+    RETURN_HR_IF_FAILED(_codeInit);
+    return _spDownload->Abort();
 }
 
-void CDownloadImpl::SetCallback(const download_property_value::status_callback_t& callback, download& download)
+int32_t CDownloadImpl::SetCallback(const download_property_value::status_callback_t& callback, download& download)
 {
+    RETURN_HR_IF_FAILED(_codeInit);
+
     Microsoft::WRL::ComPtr<DOStatusCallback> spCallback;
-    throw_if_fail(MakeAndInitialize<DOStatusCallback>(&spCallback, callback, download));
+    RETURN_HR_IF_FAILED(MakeAndInitialize<DOStatusCallback>(&spCallback, callback, download));
 
     VARIANT vtCallback;
     VariantInit(&vtCallback);
     V_VT(&vtCallback) = VT_UNKNOWN;
     V_UNKNOWN(&vtCallback) = spCallback.Get();
     spCallback.Get()->AddRef();
-    const auto hr = _spDownload->SetProperty(ConvertToComProperty(msdo::download_property::callback_interface), &vtCallback);
+    DODownloadProperty prop;
+    RETURN_HR_IF_FAILED(ConvertToComProperty(msdo::download_property::callback_interface, prop));
+    const auto hr = _spDownload->SetProperty(prop, &vtCallback);
     VariantClear(&vtCallback);
-    throw_if_fail(hr);
+    return hr;
 }
 
-msdo::download_status CDownloadImpl::GetStatus()
+// Return error code, pass in download_status by reference
+int32_t CDownloadImpl::GetStatus(msdo::download_status& status)
 {
-    DO_DOWNLOAD_STATUS status;
-    throw_if_fail(_spDownload->GetStatus(&status));
-    return ConvertFromComStatus(status);
+    RETURN_HR_IF_FAILED(_codeInit);
+    DO_DOWNLOAD_STATUS comStatus;
+    RETURN_HR_IF_FAILED(_spDownload->GetStatus(&comStatus));
+    status = ConvertFromComStatus(comStatus);
+    return S_OK;
 }
 
-msdo::download_property_value CDownloadImpl::GetProperty(msdo::download_property key)
+int32_t CDownloadImpl::GetProperty(msdo::download_property key, msdo::download_property_value& value)
 {
-    return _GetPropertyHelper(key);
+    return _GetPropertyHelper(key, value);
 }
 
-void CDownloadImpl::SetProperty(msdo::download_property key, const msdo::download_property_value& val)
+int32_t CDownloadImpl::SetProperty(msdo::download_property key, const msdo::download_property_value& val)
 {
+    RETURN_HR_IF_FAILED(_codeInit);
+
     assert(key != msdo::download_property::callback_interface);
-    _SetPropertyHelper(*_spDownload.Get(), key, val);
+    return _SetPropertyHelper(*_spDownload.Get(), key, val);
 }
 
-void CDownloadImpl::_SetPropertyHelper(IDODownload& download, msdo::download_property key, const msdo::download_property_value& val)
+int32_t CDownloadImpl::_SetPropertyHelper(IDODownload& download, msdo::download_property key, const msdo::download_property_value& val)
 {
-    DODownloadProperty prop = ConvertToComProperty(key);
+    DODownloadProperty prop;
+    RETURN_HR_IF_FAILED(ConvertToComProperty(key, prop));
 
     // COM API SetProperty() is not declared with const reference for variant argument so need to const_cast
-    throw_if_fail(download.SetProperty(prop, &const_cast<msdo::download_property_value::native_type&>(val.native_value())));
+    return download.SetProperty(prop, &const_cast<msdo::download_property_value::native_type&>(val.native_value()));
 }
 
-msdo::download_property_value CDownloadImpl::_GetPropertyHelper(msdo::download_property key)
+int32_t CDownloadImpl::_GetPropertyHelper(msdo::download_property key, msdo::download_property_value& value)
 {
-    throw E_NOTIMPL;
+    return E_NOTIMPL;
 }

--- a/sdk-cpp/src/internal/do_exceptions_internal.cpp
+++ b/sdk-cpp/src/internal/do_exceptions_internal.cpp
@@ -1,3 +1,5 @@
+#if (!DO_DISABLE_EXCEPTIONS)
+
 #include "do_exceptions_internal.h"
 
 namespace microsoft
@@ -29,3 +31,5 @@ void ThrowException(errc errorCode)
 } // namespace details
 } // namespace deliveryoptimization
 } // namespace microsoft
+
+#endif

--- a/sdk-cpp/src/internal/do_exceptions_internal.h
+++ b/sdk-cpp/src/internal/do_exceptions_internal.h
@@ -1,3 +1,4 @@
+#if !(DO_DISABLE_EXCEPTIONS)
 
 #include <exception>
 #include <stdint.h>
@@ -20,3 +21,5 @@ void ThrowException(errc error);
 } // namespace details
 } // namespace deliveryoptimization
 } // namespace microsoft
+
+#endif

--- a/sdk-cpp/src/internal/download_impl.h
+++ b/sdk-cpp/src/internal/download_impl.h
@@ -25,32 +25,36 @@ class CDownloadImpl : public IDownload
 public:
     CDownloadImpl(const std::string& uri, const std::string& downloadFilePath);
 
-    void Start() override;
-    void Pause() override;
-    void Resume() override;
-    void Finalize() override;
-    void Abort() override;
+    int32_t Start() override;
+    int32_t Pause() override;
+    int32_t Resume() override;
+    int32_t Finalize() override;
+    int32_t Abort() override;
 
-    download_status GetStatus() override;
+    int32_t GetStatus(download_status& status) override;
 
-#if defined(DO_INTERFACE_COM)
-    void SetCallback(const download_property_value::status_callback_t& callback, download& download) override;
+#if DO_INTERFACE_COM
+    int32_t SetCallback(const download_property_value::status_callback_t& callback, download& download) override;
 
-    download_property_value GetProperty(download_property key) override;
-    void SetProperty(download_property key, const download_property_value& val) override;
+    int32_t GetProperty(download_property key, download_property_value& value) override;
+    int32_t SetProperty(download_property key, const download_property_value& val) override;
 #endif
 
 private:
+    int32_t _Initialize(const std::string& uri, const std::string& downloadFilePath);
+
 #if defined(DO_INTERFACE_COM)
-    static void _SetPropertyHelper(IDODownload& download, download_property key, const download_property_value& val);
-    download_property_value _GetPropertyHelper(download_property key);
+    static int32_t _SetPropertyHelper(IDODownload& download, download_property key, const download_property_value& val);
+    int32_t _GetPropertyHelper(download_property key, download_property_value& value);
 
     Microsoft::WRL::ComPtr<IDODownload> _spDownload;
 #elif defined(DO_INTERFACE_REST)
-    void _DownloadOperationCall(const std::string& type);
+    int32_t _DownloadOperationCall(const std::string& type);
 
     std::string _id;
 #endif
+    
+    int32_t _codeInit;
 };
 
 } // namespace details

--- a/sdk-cpp/src/internal/download_interface.h
+++ b/sdk-cpp/src/internal/download_interface.h
@@ -21,20 +21,20 @@ class IDownload
 public:
     virtual ~IDownload() = default;
 
-    virtual void Start() = 0;
-    virtual void Pause() = 0;
-    virtual void Resume() = 0;
-    virtual void Finalize() = 0;
-    virtual void Abort() = 0;
+    virtual int32_t Start() = 0;
+    virtual int32_t Pause() = 0;
+    virtual int32_t Resume() = 0;
+    virtual int32_t Finalize() = 0;
+    virtual int32_t Abort() = 0;
 
-    virtual download_status GetStatus() = 0;
+    virtual int32_t GetStatus(download_status& status) = 0;
 
 #if defined(DO_INTERFACE_COM)
-    virtual download_property_value GetProperty(download_property key) = 0;
+    virtual int32_t GetProperty(download_property key, download_property_value& value) = 0;
 
-    virtual void SetProperty(download_property key, const download_property_value& val) = 0;
+    virtual int32_t SetProperty(download_property key, const download_property_value& val) = 0;
 
-    virtual void SetCallback(const download_property_value::status_callback_t& callback, download& download) = 0;
+    virtual int32_t SetCallback(const download_property_value::status_callback_t& callback, download& download) = 0;
 #endif
 };
 } // namespace details

--- a/sdk-cpp/tests/download_tests_common.cpp
+++ b/sdk-cpp/tests/download_tests_common.cpp
@@ -90,7 +90,7 @@ TEST_F(DownloadTests, CancelBlockingDownloadTest)
         }
         catch (const msdo::exception& e)
         {
-            ASSERT_EQ(e.error_code(), static_cast<int32_t>(std::errc::operation_canceled));
+            ASSERT_EQ(e.error_code(), HRESULT_FROM_SYSTEM_ERROR(static_cast<int32_t>(std::errc::operation_canceled)));
         }
     });
     std::this_thread::sleep_for(1s);
@@ -109,7 +109,7 @@ TEST_F(DownloadTests, BlockingDownloadTimeout)
     }
     catch (const msdo::exception& e)
     {
-        ASSERT_EQ(e.error_code(), static_cast<int32_t>(std::errc::timed_out));
+        ASSERT_EQ(e.error_code(), HRESULT_FROM_SYSTEM_ERROR(static_cast<int32_t>(std::errc::timed_out)));
         auto elapsedTime = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - startTime);
         ASSERT_GE(elapsedTime, std::chrono::seconds(2));
         ASSERT_LE(elapsedTime, std::chrono::seconds(5));
@@ -484,7 +484,7 @@ TEST_F(DownloadTests, MultipleConcurrentDownloadTest_WithCancels)
         }
         catch (const msdo::exception& e)
         {
-            ASSERT_EQ(e.error_code(), static_cast<int32_t>(std::errc::operation_canceled));
+            ASSERT_EQ(e.error_code(), HRESULT_FROM_SYSTEM_ERROR(static_cast<int32_t>(std::errc::operation_canceled)));
         }
     });
     std::thread downloadThread3([&]()

--- a/sdk-cpp/tests/rest/network_connectivity_tests.cpp
+++ b/sdk-cpp/tests/rest/network_connectivity_tests.cpp
@@ -46,7 +46,7 @@ TEST_F(NetworkConnectivityTests, DISABLED_SimpleBlockingDownloadNetworkDisconnec
             }
             catch (const msdo::exception& e)
             {
-                ASSERT_EQ(e.error_code(), static_cast<int32_t>(std::errc::timed_out));
+                ASSERT_EQ(e.error_code(), HRESULT_FROM_SYSTEM_ERROR(static_cast<int32_t>(std::errc::timed_out)));
             }
         });
     TestHelpers::DisableNetwork();


### PR DESCRIPTION
- Enable building SDK without exceptions 
- Remove internal exceptions except for:
1. There are still internal exceptions in our utility classes for the rest interface side of things. Looking for feedback here.
2. download_property class is quite awkward if we remove exceptions, it feels awkward to have an Init/Clear method for it since it's a thin wrapper around VARIANT or another polymorphic type for the rest interface. Looking for feedback here. 
- Tests run succesfully across both windows/linux