### PR TITLE
Trigger pipelines for develop instead of main.

### DIFF
--- a/azure-pipelines/build/linux/du/doclient-lite-native.yml
+++ b/azure-pipelines/build/linux/du/doclient-lite-native.yml
@@ -8,7 +8,7 @@ variables:
 trigger:
   branches:
     include:
-      - main
+      - develop
   paths:
     include:
       - azure-pipelines/build/linux/du/doclient-lite-native.yml
@@ -23,7 +23,7 @@ trigger:
 pr:
   branches:
     include:
-      - main
+      - develop
   paths:
     include:
       - azure-pipelines/build/linux/du/doclient-lite-native.yml

--- a/azure-pipelines/build/linux/du/dopapt-native.yml
+++ b/azure-pipelines/build/linux/du/dopapt-native.yml
@@ -8,7 +8,7 @@ variables:
 trigger:
   branches:
     include:
-      - main
+      - develop
   paths:
     include:
       - azure-pipelines/build/linux/du/dopapt-native.yml
@@ -24,7 +24,7 @@ trigger:
 pr:
   branches:
     include:
-      - main
+      - develop
   paths:
     include:
       - azure-pipelines/build/linux/du/dopapt-native.yml

--- a/azure-pipelines/build/linux/du/dosdkcpp-native.yml
+++ b/azure-pipelines/build/linux/du/dosdkcpp-native.yml
@@ -9,7 +9,7 @@ variables:
 trigger:
   branches:
     include:
-      - main
+      - develop
   paths:
     include:
       - azure-pipelines/build/linux/du/dosdkcpp-native.yml
@@ -25,7 +25,7 @@ trigger:
 pr:
   branches:
     include:
-      - main
+      - develop
   paths:
     include:
       - azure-pipelines/build/linux/du/dosdkcpp-native.yml

--- a/azure-pipelines/build/mac/dosdkcpp.yml
+++ b/azure-pipelines/build/mac/dosdkcpp.yml
@@ -1,10 +1,10 @@
-# Pipeline to build the DO CPP SDK on Windows 10 
+# Pipeline to build the DO CPP SDK on Windows 10
 # Runs tests after build and publishes the binaries as artifacts
 
 trigger:
   branches:
     include:
-      - main
+      - develop
       - feature/xplat_sdk
   paths:
     include:
@@ -14,13 +14,13 @@ trigger:
       - build/build.py
       - CMakeLists.txt
     exclude:
-      - 'azure-pipelines/*'
+      - azure-pipelines/*
       - sdk-cpp/build/cleanup-install.sh
 
 pr:
   branches:
     include:
-      - main
+      - develop
       - feature/xplat_sdk
   paths:
     include:
@@ -30,7 +30,7 @@ pr:
       - build/build.py
       - CMakeLists.txt
     exclude:
-      - 'azure-pipelines/*'
+      - azure-pipelines/*
       - sdk-cpp/build/cleanup-install.sh
 
 pool:

--- a/azure-pipelines/build/windows/dosdkcpp.yml
+++ b/azure-pipelines/build/windows/dosdkcpp.yml
@@ -1,10 +1,10 @@
-# Pipeline to build the DO CPP SDK on Windows 10 
+# Pipeline to build the DO CPP SDK on Windows 10
 # Runs tests after build and publishes the binaries as artifacts
 
 trigger:
   branches:
     include:
-      - main
+      - develop
       - feature/xplat_sdk
   paths:
     include:
@@ -14,13 +14,13 @@ trigger:
       - build/build.py
       - CMakeLists.txt
     exclude:
-      - 'azure-pipelines/*'
+      - azure-pipelines/*
       - sdk-cpp/build/cleanup-install.sh
 
 pr:
   branches:
     include:
-      - main
+      - develop
       - feature/xplat_sdk
   paths:
     include:
@@ -30,7 +30,7 @@ pr:
       - build/build.py
       - CMakeLists.txt
     exclude:
-      - 'azure-pipelines/*'
+      - azure-pipelines/*
       - sdk-cpp/build/cleanup-install.sh
 
 pool:


### PR DESCRIPTION
* With creation of develop, main will not see frequent changes.
* main can be covered by the release pipeline alone.