### PR TITLE
Increment versions for develop

### DIFF
--- a/client-lite/CMakeLists.txt
+++ b/client-lite/CMakeLists.txt
@@ -5,7 +5,7 @@ if (NOT DOSVC_BIN_NAME)
     message (FATAL_ERROR "Agent daemon name not defined")
 endif ()
 
-project (${DOSVC_BIN_NAME} VERSION 0.6.0)
+project (${DOSVC_BIN_NAME} VERSION 0.7.0)
 
 option (DO_PROXY_SUPPORT "Set DO_PROXY_SUPPORT to OFF to turn off proxy support for downloads and thus remove dependency on libproxy." ON)
 

--- a/plugins/linux-apt/CMakeLists.txt
+++ b/plugins/linux-apt/CMakeLists.txt
@@ -5,7 +5,7 @@ if (NOT DO_PLUGIN_APT_BIN_NAME)
     message (FATAL_ERROR "APT plugin binary name not defined")
 endif ()
 
-project (${DO_PLUGIN_APT_BIN_NAME} VERSION 0.4.0)
+project (${DO_PLUGIN_APT_BIN_NAME} VERSION 0.5.0)
 
 find_package(deliveryoptimization_sdk CONFIG REQUIRED)
 find_package(OpenSSL REQUIRED)

--- a/sdk-cpp/CMakeLists.txt
+++ b/sdk-cpp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-project (deliveryoptimization_sdk VERSION 0.6.0)
+project (deliveryoptimization_sdk VERSION 0.7.0)
 
 if (DO_PLATFORM_LINUX OR DO_PLATFORM_MAC)
     message("DO configured to use shared Boost libraries")


### PR DESCRIPTION
* Increment post-v0.8.0 release.
* The idea is to be able to always differentiate between released and development versions.