### PR TITLE
Templatize Github release jobs per platform & Tar the .deb output

### DIFF
--- a/azure-pipelines/build/linux/du/templates/dopapt-docker-steps.yml
+++ b/azure-pipelines/build/linux/du/templates/dopapt-docker-steps.yml
@@ -10,8 +10,6 @@ parameters:
   type: string
 
 steps:
-- checkout: self
-
 - task: Docker@2
   displayName: Login to ACR
   inputs:

--- a/azure-pipelines/build/linux/du/templates/dopapt-native-steps.yml
+++ b/azure-pipelines/build/linux/du/templates/dopapt-native-steps.yml
@@ -8,8 +8,6 @@ parameters:
   type: string
 
 steps:
-- checkout: self
-
 - task: CmdLine@2
   inputs:
     script: 'python3 ./build.py --project sdk --cmaketarget deliveryoptimization --config ${{parameters.config}} --package-for DEB --clean'

--- a/azure-pipelines/publishing/github-release.yml
+++ b/azure-pipelines/publishing/github-release.yml
@@ -38,91 +38,21 @@ stages:
 
 - stage: release_build
   jobs:
-  - job: deliveryoptimization_agent_ubuntu1804_amd64
-    steps:
-    - template: ../build/linux/du/templates/doclient-lite-native-steps.yml
-      parameters:
-        targetOsArch: 'ubuntu1804_x64'
-        config: minsizerel
-        skipTests: true
-  - job: deliveryoptimization_agent_ubuntu1804_arm64
-    steps:
-    - template: ../build/linux/du/templates/doclient-lite-docker-steps.yml
-      parameters:
-        targetOsArch: ubuntu1804_arm64
-        imageVersion: ${{variables.imageVersion}}
-        config: minsizerel
-  - job: deliveryoptimization_agent_debian10_arm32
-    steps:
-    - template: ../build/linux/du/templates/doclient-lite-docker-steps.yml
-      parameters:
-        targetOsArch: debian10_arm32
-        imageVersion: ${{variables.imageVersion}}
-        config: minsizerel
-  - job: deliveryoptimization_agent_debian9_arm32
-    steps:
-    - template: ../build/linux/du/templates/doclient-lite-docker-steps.yml
-      parameters:
-        targetOsArch: debian9_arm32
-        imageVersion: ${{variables.imageVersion}}
-        config: minsizerel
-
-  - job: libdeliveryoptimization_ubuntu1804_amd64
-    steps:
-    - template: ../build/linux/du/templates/dosdkcpp-native-steps.yml
-      parameters:
-        targetOsArch: ubuntu1804_x64
-        config: minsizerel
-        skipTests: true
-  - job: libdeliveryoptimization_ubuntu1804_arm64
-    steps:
-    - template: ../build/linux/du/templates/dosdkcpp-docker-steps.yml
-      parameters:
-        targetOsArch: ubuntu1804_arm64
-        imageVersion: ${{variables.imageVersion}}
-        config: minsizerel
-  - job: libdeliveryoptimization_debian10_arm32
-    steps:
-    - template: ../build/linux/du/templates/dosdkcpp-docker-steps.yml
-      parameters:
-        targetOsArch: debian10_arm32
-        imageVersion: ${{variables.imageVersion}}
-        config: minsizerel
-  - job: libdeliveryoptimization_debian9_arm32
-    steps:
-    - template: ../build/linux/du/templates/dosdkcpp-docker-steps.yml
-      parameters:
-        targetOsArch: debian9_arm32
-        imageVersion: ${{variables.imageVersion}}
-        config: minsizerel
-
-  - job: deliveryoptimization_plugin_apt_ubuntu1804_amd64
-    steps:
-    - template: ../build/linux/du/templates/dopapt-native-steps.yml
-      parameters:
-        targetOsArch: ubuntu1804_x64
-        config: minsizerel
-  - job: deliveryoptimization_plugin_apt_ubuntu1804_arm64
-    steps:
-    - template: ../build/linux/du/templates/dopapt-docker-steps.yml
-      parameters:
-        targetOsArch: ubuntu1804_arm64
-        imageVersion: ${{variables.imageVersion}}
-        config: minsizerel
-  - job: deliveryoptimization_plugin_apt_debian10_arm32
-    steps:
-    - template: ../build/linux/du/templates/dopapt-docker-steps.yml
-      parameters:
-        targetOsArch: debian10_arm32
-        imageVersion: ${{variables.imageVersion}}
-        config: minsizerel
-  - job: deliveryoptimization_plugin_apt_debian9_arm32
-    steps:
-    - template: ../build/linux/du/templates/dopapt-docker-steps.yml
-      parameters:
-        targetOsArch: debian9_arm32
-        imageVersion: ${{variables.imageVersion}}
-        config: minsizerel
+  - template: templates/release-native-build-steps.yml
+    parameters:
+      targetOsArch: 'ubuntu1804_x64'
+  - template: templates/release-docker-build-steps.yml
+    parameters:
+      targetOsArch: 'ubuntu1804_arm64'
+      imageVersion: ${{variables.imageVersion}}
+  - template: templates/release-docker-build-steps.yml
+    parameters:
+      targetOsArch: 'debian9_arm32'
+      imageVersion: ${{variables.imageVersion}}
+  - template: templates/release-docker-build-steps.yml
+    parameters:
+      targetOsArch: 'debian10_arm32'
+      imageVersion: ${{variables.imageVersion}}
 
 - stage: release
   condition: succeeded()
@@ -140,7 +70,7 @@ stages:
         script: |
           echo "Directory to be published: $(Build.ArtifactStagingDirectory)"
           echo Content to be published:
-          ls -lR $(Build.ArtifactStagingDirectory)
+          ls -lR $(Build.ArtifactStagingDirectory)/**/*.tar
       displayName: Release Information
 
     - task: GitHubRelease@1
@@ -149,7 +79,7 @@ stages:
         gitHubConnection: 'client2'
         repositoryName: 'microsoft/do-client'
         action: 'create'
-        assets: '$(Build.ArtifactStagingDirectory)/**/*-minsizerel/*.deb'
+        assets: '$(Build.ArtifactStagingDirectory)/**/*.tar'
         tagSource: 'userSpecifiedTag'
         tag: '$(Release.Version)'
         title: '$(Release.Title)'

--- a/azure-pipelines/publishing/templates/release-docker-build-steps.yml
+++ b/azure-pipelines/publishing/templates/release-docker-build-steps.yml
@@ -1,0 +1,74 @@
+# Template: Steps to build all components for a specific OS
+# Consume this steps template in one or more jobs by passing in parameter values.
+
+parameters:
+- name: targetOsArch        # example: debian9_arm32
+  type: string
+- name: imageVersion
+  type: string
+
+
+jobs:
+- job: ${{parameters.targetOsArch}}
+  steps:
+  - checkout: self
+    path: 's' # Copy to sources directory (templates do not do this automatically)
+  - template: ../../build/linux/du/templates/doclient-lite-docker-steps.yml
+    parameters:
+      targetOsArch: ${{parameters.targetOsArch}}
+      imageVersion: ${{parameters.imageVersion}}
+      config: minsizerel
+  - task: CopyFiles@2
+    inputs:
+      SourceFolder: '/tmp/build-deliveryoptimization-agent-${{parameters.targetOsArch}}/linux-minsizerel'
+      Contents: |
+          *.deb
+      TargetFolder: '/tmp/${{parameters.targetOsArch}}'
+      CleanTargetFolder: true
+    displayName: 'Copy all agent .deb file'
+
+  - template: ../../build/linux/du/templates/dosdkcpp-docker-steps.yml
+    parameters:
+      targetOsArch: ${{parameters.targetOsArch}}
+      imageVersion: ${{parameters.imageVersion}}
+      config: minsizerel
+  - task: CopyFiles@2
+    inputs:
+      SourceFolder: '/tmp/build-deliveryoptimization-sdk-${{parameters.targetOsArch}}/linux-minsizerel'
+      Contents: |
+          *.deb
+      TargetFolder: '/tmp/${{parameters.targetOsArch}}'
+      CleanTargetFolder: false
+    displayName: 'Copy sdk .deb files'
+
+  - template: ../../build/linux/du/templates/dopapt-docker-steps.yml
+    parameters:
+      targetOsArch: ${{parameters.targetOsArch}}
+      imageVersion: ${{parameters.imageVersion}}
+      config: minsizerel
+  - task: CopyFiles@2
+    inputs:
+      SourceFolder: '/tmp/build-deliveryoptimization-plugin-apt-${{parameters.targetOsArch}}/linux-minsizerel'
+      Contents: |
+          *.deb
+      TargetFolder: '/tmp/${{parameters.targetOsArch}}'
+      CleanTargetFolder: false
+    displayName: 'Copy plugin .deb file'
+  - task: DeleteFiles@1
+    inputs: 
+      SourceFolder: $(Build.ArtifactStagingDirectory)
+      Contents: |
+        **/*
+    displayName: 'Clean build folder before creating tar file folder'
+  - task: ArchiveFiles@2
+    inputs: 
+      rootFolderOrFile: /tmp/${{parameters.targetOsArch}}
+      includeRootFolder: False
+      archiveType: tar
+      archiveFile: $(build.ArtifactStagingDirectory)/${{parameters.targetOsArch}}-packages.tar
+    displayName: 'Create .tar file'
+  - task: PublishBuildArtifacts@1
+    inputs:
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      ArtifactName: '${{parameters.targetOsArch}}'
+      publishLocation: 'Container'

--- a/azure-pipelines/publishing/templates/release-native-build-steps.yml
+++ b/azure-pipelines/publishing/templates/release-native-build-steps.yml
@@ -1,0 +1,67 @@
+parameters:
+- name: targetOsArch        # example: debian9_arm32
+  type: string
+
+jobs:
+- job: ${{parameters.targetOsArch}}
+  steps:
+  - checkout: self
+    path: 's' # Copy to sources directory (templates do not do this automatically)
+  - template: ../../build/linux/du/templates/doclient-lite-native-steps.yml
+    parameters:
+      targetOsArch: ${{parameters.targetOsArch}}
+      config: minsizerel
+      skiptests: true
+  - task: CopyFiles@2
+    inputs:
+      SourceFolder: '/tmp/build-deliveryoptimization-agent/linux-minsizerel'
+      Contents: |
+          *.deb
+      TargetFolder: '/tmp/${{parameters.targetOsArch}}'
+      CleanTargetFolder: true
+    displayName: 'Copy agent .deb file'
+
+  - template: ../../build/linux/du/templates/dosdkcpp-native-steps.yml
+    parameters:
+      targetOsArch: ${{parameters.targetOsArch}}
+      config: minsizerel
+      skiptests: true
+  - task: CopyFiles@2
+    inputs:
+      SourceFolder: '/tmp/build-deliveryoptimization-sdk/linux-minsizerel'
+      Contents: |
+          *.deb
+      TargetFolder: '/tmp/${{parameters.targetOsArch}}'
+      CleanTargetFolder: false
+    displayName: 'Copy sdk .deb files'
+
+  - template: ../../build/linux/du/templates/dopapt-native-steps.yml
+    parameters:
+      targetOsArch: ${{parameters.targetOsArch}}
+      config: minsizerel
+  - task: CopyFiles@2
+    inputs:
+      SourceFolder: '/tmp/build-deliveryoptimization-plugin-apt/linux-minsizerel'
+      Contents: |
+          *.deb
+      TargetFolder: '/tmp/${{parameters.targetOsArch}}'
+      CleanTargetFolder: false
+    displayName: 'Copy plugin .deb file'
+  - task: DeleteFiles@1
+    inputs: 
+      SourceFolder: $(Build.ArtifactStagingDirectory)
+      Contents: |
+        **/*
+    displayName: 'Clean build folder before creating tar file folder'
+  - task: ArchiveFiles@2
+    inputs: 
+      rootFolderOrFile: /tmp/${{parameters.targetOsArch}}
+      includeRootFolder: False
+      archiveType: tar
+      archiveFile: $(build.ArtifactStagingDirectory)/${{parameters.targetOsArch}}-packages.tar
+    displayName: 'Create .tar file'
+  - task: PublishBuildArtifacts@1
+    inputs:
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      ArtifactName: '${{parameters.targetOsArch}}'
+      publishLocation: 'Container'


### PR DESCRIPTION
- Tested this on a dry-run and release now contains 4 tar files respective to each platform
- It's a little messy the way this pipeline does the .tar file creation so that can be cleaned up in the future