### PR TITLE
Fix build warnings

### DIFF
--- a/client-lite/src/trace/do_log.cpp
+++ b/client-lite/src/trace/do_log.cpp
@@ -252,15 +252,21 @@ private:
         char filePath[512];
         const auto hr = StringPrintf(filePath, ARRAYSIZE(filePath), "%s/%s%s.log", _logDir.c_str(), g_logFileNamePrefix, timestamp.data());
         DO_ASSERT(SUCCEEDED(hr));
-
-        _logFile.open(filePath, std::fstream::out | std::fstream::app);
-        if (_logFile.fail())
+        if (SUCCEEDED(hr))
         {
-            fprintf(stderr, "Failed to create log file at %s\n", filePath);
+            _logFile.open(filePath, std::fstream::out | std::fstream::app);
+            if (_logFile.fail())
+            {
+                fprintf(stderr, "Failed to create log file at %s\n", filePath);
+            }
+            else
+            {
+                ++_stats.numFilesCreated;
+            }
         }
         else
         {
-            ++_stats.numFilesCreated;
+            fprintf(stderr, "Failed to construct log file name with timestamp: %s\n", timestamp.data());
         }
     }
 

--- a/sdk-cpp/tests_nothrow/download_properties_tests.cpp
+++ b/sdk-cpp/tests_nothrow/download_properties_tests.cpp
@@ -155,7 +155,7 @@ TEST_F(DownloadPropertyTestsDOSVC_NoThrow, CallbackTestUseDownload)
     msdo::download_property_value callback = g_MakePropertyValue([&fPauseDownload](msdo::download& download, msdo::download_status& status)
         {
             char msgBuf[1024];
-            snprintf(msgBuf, sizeof(msgBuf), "Received status callback: %llu/%llu, 0x%x, 0x%x, %u",
+            snprintf(msgBuf, sizeof(msgBuf), "Received status callback: %lu/%lu, 0x%x, 0x%x, %u",
                 status.bytes_transferred(), status.bytes_total(), status.error_code().value(), status.extended_error_code().value(),
                 static_cast<unsigned int>(status.state()));
             std::cout << msgBuf << std::endl;
@@ -184,7 +184,7 @@ TEST_F(DownloadPropertyTestsDOSVC_NoThrow, SetCallbackTest)
     msdo::download_property_value callback = g_MakePropertyValue([&i](msdo::download& download, msdo::download_status& status)
         {
             char msgBuf[1024];
-            snprintf(msgBuf, sizeof(msgBuf), "Received status callback: %llu/%llu, 0x%x, 0x%x, %u",
+            snprintf(msgBuf, sizeof(msgBuf), "Received status callback: %lu/%lu, 0x%x, 0x%x, %u",
                 status.bytes_transferred(), status.bytes_total(), status.error_code().value(), status.extended_error_code().value(),
                 static_cast<unsigned int>(status.state()));
             std::cout << msgBuf << std::endl;

--- a/sdk-cpp/tests_nothrow/download_tests.cpp
+++ b/sdk-cpp/tests_nothrow/download_tests.cpp
@@ -17,14 +17,6 @@
 namespace msdo = microsoft::deliveryoptimization;
 using namespace std::chrono_literals;
 
-static double TimeOperation(const std::function<void()>& op)
-{
-    auto start = std::chrono::steady_clock::now();
-    op();
-    auto end = std::chrono::steady_clock::now();
-    return std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
-}
-
 class DownloadTestsDOSVC : public ::testing::Test
 {
 public:


### PR DESCRIPTION
* Unused local variable in release build in do_log.cpp.
* Incorrect format specifier for uint64_t.
* Unused method TimeOperation.