### PR TITLE
fix/allow admin to override mcc config with empty string

### DIFF
--- a/client-lite/src/config/config_manager.cpp
+++ b/client-lite/src/config/config_manager.cpp
@@ -43,10 +43,10 @@ boost::optional<std::chrono::seconds> ConfigManager::CacheHostFallbackDelay()
     return returnValue;
 }
 
-std::string ConfigManager::CacheHostServer()
+boost::optional<std::string> ConfigManager::CacheHostServer()
 {
     boost::optional<std::string> cacheHostServer = _adminConfigs.Get<std::string>(ConfigName_CacheHostServer);
-    return boost::get_optional_value_or(cacheHostServer, std::string{});
+    return cacheHostServer;
 }
 
 std::string ConfigManager::IoTConnectionString()
@@ -59,4 +59,4 @@ bool ConfigManager::RestControllerValidateRemoteAddr()
 {
     boost::optional<bool> validateRemoteAddr = _adminConfigs.Get<bool>(ConfigName_RestControllerValidateRemoteAddr);
     return boost::get_optional_value_or(validateRemoteAddr, g_RestControllerValidateRemoteAddrDefault);
-}
+}   

--- a/client-lite/src/config/config_manager.h
+++ b/client-lite/src/config/config_manager.h
@@ -15,7 +15,7 @@ public:
     void RefreshAdminConfigs();
 
     boost::optional<std::chrono::seconds> CacheHostFallbackDelay();
-    std::string CacheHostServer();
+    boost::optional<std::string> CacheHostServer();
     std::string IoTConnectionString();
     bool RestControllerValidateRemoteAddr();
 

--- a/client-lite/src/config/mcc_manager.cpp
+++ b/client-lite/src/config/mcc_manager.cpp
@@ -50,14 +50,18 @@ boost::optional<std::chrono::seconds> MCCManager::FallbackDelay()
 
 std::string MCCManager::GetHost()
 {
-    std::string mccHostName =_configManager.CacheHostServer();
-    if (mccHostName.empty())
+    boost::optional<std::string> mccHostNameOpt =_configManager.CacheHostServer();
+    std::string mccHostName;
+
+    if (!mccHostNameOpt.is_initialized())
     {
         const std::string connString = _configManager.IoTConnectionString();
         if (!connString.empty())
         {
             mccHostName = GetHostNameFromIoTConnectionString(connString.data());
         }
+    } else {
+        mccHostName = mccHostNameOpt.get();
     }
 
     DoLogVerbose("Returning MCC host: [%s]", mccHostName.c_str());

--- a/client-lite/src/config/mcc_manager.cpp
+++ b/client-lite/src/config/mcc_manager.cpp
@@ -53,17 +53,17 @@ std::string MCCManager::GetHost()
     boost::optional<std::string> mccHostNameOpt =_configManager.CacheHostServer();
     std::string mccHostName;
 
-    if (!mccHostNameOpt.is_initialized())
+    if (mccHostNameOpt.is_initialized())
+    {
+        mccHostName = mccHostNameOpt.get();
+    }
+    else
     {
         const std::string connString = _configManager.IoTConnectionString();
         if (!connString.empty())
         {
             mccHostName = GetHostNameFromIoTConnectionString(connString.data());
         }
-    }
-    else
-    {
-        mccHostName = mccHostNameOpt.get();
     }
 
     DoLogVerbose("Returning MCC host: [%s]", mccHostName.c_str());

--- a/client-lite/src/config/mcc_manager.cpp
+++ b/client-lite/src/config/mcc_manager.cpp
@@ -60,7 +60,9 @@ std::string MCCManager::GetHost()
         {
             mccHostName = GetHostNameFromIoTConnectionString(connString.data());
         }
-    } else {
+    }
+    else
+    {
         mccHostName = mccHostNameOpt.get();
     }
 

--- a/client-lite/test/mcc_manager.tests.cpp
+++ b/client-lite/test/mcc_manager.tests.cpp
@@ -116,6 +116,16 @@ TEST_F(MCCManagerTests, AdminConfigOverride)
     SetIoTConnectionString("HostName=instance-company-iothub-ver.host.tld;DeviceId=user-dev-name;SharedAccessKey=abcdefghijklmnopqrstuvwxyzABCDE123456789012=;GatewayHostName=" TEST_MOCK_MCC_HOST);
     SetDOCacheHostConfig(TEST_MOCK_MCC_HOST2);
     _VerifyExpectedCacheHost(TEST_MOCK_MCC_HOST2);
+    
+    cppfs::remove(g_adminConfigFilePath);
+    _VerifyExpectedCacheHost(TEST_MOCK_MCC_HOST);
+}
+
+TEST_F(MCCManagerTests, AdminConfigEmptyString)
+{
+    SetIoTConnectionString("HostName=instance-company-iothub-ver.host.tld;DeviceId=user-dev-name;SharedAccessKey=abcdefghijklmnopqrstuvwxyzABCDE123456789012=;GatewayHostName=" TEST_MOCK_MCC_HOST);
+    SetDOCacheHostConfig("");
+    _VerifyExpectedCacheHost("");
 
     cppfs::remove(g_adminConfigFilePath);
     _VerifyExpectedCacheHost(TEST_MOCK_MCC_HOST);

--- a/client-lite/test/mcc_manager.tests.cpp
+++ b/client-lite/test/mcc_manager.tests.cpp
@@ -116,7 +116,7 @@ TEST_F(MCCManagerTests, AdminConfigOverride)
     SetIoTConnectionString("HostName=instance-company-iothub-ver.host.tld;DeviceId=user-dev-name;SharedAccessKey=abcdefghijklmnopqrstuvwxyzABCDE123456789012=;GatewayHostName=" TEST_MOCK_MCC_HOST);
     SetDOCacheHostConfig(TEST_MOCK_MCC_HOST2);
     _VerifyExpectedCacheHost(TEST_MOCK_MCC_HOST2);
-    
+
     cppfs::remove(g_adminConfigFilePath);
     _VerifyExpectedCacheHost(TEST_MOCK_MCC_HOST);
 }


### PR DESCRIPTION
BUG 40525399:

ADU DO Client: Allow admins to override MCC config with 'empty string' to disable MCC usage