### PR TITLE
Agent: Fix debian package upgrade issue

### DIFF
--- a/client-lite/build/postinst.in.sh
+++ b/client-lite/build/postinst.in.sh
@@ -14,7 +14,7 @@ svc_bin_path=@docs_svc_bin_path@
 # Exit early to fail the install if any command here fails
 set -e
 
-echo "Running post-install script for $svc_name, args: $1, $2"
+echo "**** Running post-install script for $svc_name, args: $1 $2 ****"
 
 if [ ! -f $svc_bin_path ]; then echo "Agent binary cannot be found at $svc_bin_path"; exit 1; fi
 
@@ -73,9 +73,9 @@ echo "Service conf stored at: $svc_config_path"
 echo "Service bin located at: $svc_bin_path"
 echo "Reloading systemd daemon list and enabling $svc_name"
 systemctl daemon-reload
+systemctl enable $svc_name
 # Installed/upgraded daemon; remove from the failed services list. No-op if never failed earlier.
 systemctl reset-failed $svc_name
-systemctl enable $svc_name
 systemctl stop $svc_name > /dev/null # stop if already running
 systemctl start $svc_name
 echo "Done!"

--- a/client-lite/build/postinst.in.sh
+++ b/client-lite/build/postinst.in.sh
@@ -43,11 +43,11 @@ done
 configure_dir() {
     local dir_path="$1"
     echo "Configuring dir: $dir_path"
-    if [ ! -d $dir_path ]; then
-        mkdir $dir_path
+    if [ ! -d "$dir_path" ]; then
+        mkdir "$dir_path"
     fi
-    chgrp -R $do_group_name $dir_path
-    chown $do_user_name $dir_path
+    chgrp -R $do_group_name "$dir_path"
+    chown $do_user_name "$dir_path"
 }
 
 configure_dir "$config_path"
@@ -78,4 +78,4 @@ systemctl enable $svc_name
 systemctl reset-failed $svc_name
 systemctl stop $svc_name > /dev/null # stop if already running
 systemctl start $svc_name
-echo "Done!"
+echo "**** Done! ****"

--- a/client-lite/build/postrm.in.sh
+++ b/client-lite/build/postrm.in.sh
@@ -58,8 +58,7 @@ case "$1" in
     # upgrade: Removing user/group/directories during an upgrade is a mistake that can impact group membership, historical logs, etc.
     # abort-install, abort-upgrade: This project does not use any package install path that requires handling these cases.
     upgrade|abort-install|abort-upgrade)
-        exit 0
     ;;
 esac
 
-echo "Done!"
+echo "**** Done! ****"

--- a/client-lite/build/postrm.in.sh
+++ b/client-lite/build/postrm.in.sh
@@ -11,7 +11,7 @@ run_path=@docs_svc_run_dir_path@
 svc_name=@docs_svc_name@
 svc_config_path=@docs_systemd_cfg_path@
 
-echo "Running post-removal script for $svc_name, args: $1, $2"
+echo "**** Running post-removal script for $svc_name, args: $1 $2 ****"
 
 do_remove_daemon() {
     echo "Removing systemd unit file: $svc_config_path"

--- a/client-lite/build/postrm.in.sh
+++ b/client-lite/build/postrm.in.sh
@@ -11,29 +11,55 @@ run_path=@docs_svc_run_dir_path@
 svc_name=@docs_svc_name@
 svc_config_path=@docs_systemd_cfg_path@
 
-echo "Running post-removal script for $svc_name"
+echo "Running post-removal script for $svc_name, args: $1, $2"
 
-systemctl reset-failed $svc_name # Remove ourselves from the failed services list. No-op if never failed earlier.
+do_remove_daemon() {
+    echo "Removing systemd unit file: $svc_config_path"
+    rm $svc_config_path
 
-echo "Removing systemd unit file: $svc_config_path"
-rm $svc_config_path
+    echo "Reloading daemons"
+    systemctl daemon-reload
+}
 
-echo "Reloading daemons"
-systemctl daemon-reload
+do_remove_dirs() {
+    echo "Removing log directory: $log_path"
+    rm -rf $log_path
 
-echo "Removing log directory: $log_path"
-rm -rf $log_path
+    echo "Removing run directory: $run_path"
+    rm -rf $run_path
+}
 
-echo "Removing config directory: $config_path"
-rm -rf $config_path
+do_remove_user_and_group() {
+    echo "Removing user: ${do_user_name}"
+    userdel ${do_user_name}
 
-echo "Removing run directory: $run_path"
-rm -rf $run_path
+    echo "Removing group: ${do_group_name}"
+    groupdel ${do_group_name}
+}
 
-echo "Removing user: ${do_user_name}"
-userdel ${do_user_name}
+do_remove_tasks() {
+    do_remove_daemon
+    do_remove_dirs
+    do_remove_user_and_group
+}
 
-echo "Removing group: ${do_group_name}"
-groupdel ${do_group_name}
+case "$1" in
+    remove)
+        do_remove_tasks
+    ;;
+
+    purge)
+        do_remove_tasks
+
+        echo "Removing config directory: $config_path"
+        rm -rf $config_path
+    ;;
+
+    # upgrade: Removing user/group/directories during an upgrade is a mistake that can impact group membership, historical logs, etc.
+    # abort-install, abort-upgrade: This project does not use any package install path that requires handling these cases.
+    upgrade|abort-install|abort-upgrade)
+        exit 0
+    ;;
+esac
 
 echo "Done!"

--- a/client-lite/build/prerm.in.sh
+++ b/client-lite/build/prerm.in.sh
@@ -5,10 +5,10 @@
 
 svc_name=@docs_svc_name@
 
-echo "Running pre-removal script for $svc_name"
+echo "**** Running pre-removal script for $svc_name, args: $1 $2 ****"
 
 echo "Stopping and disabling service $svc_name"
 systemctl stop $svc_name
 systemctl disable $svc_name
 
-echo "Done!"
+echo "**** Done! ****"


### PR DESCRIPTION
* During an upgrade, postrm script deletes the 'do' group causing 'adu' membership to be removed.
* postrm script is now updated to perform cleanup only on remove and purge actions. postinst script already handled the case of existing user/group entities.
* Also move systemctl reset-failed to postinst as the more appropriate location. If retaining in prerm, we will have to take a call on whether to call it only on upgrade/abort-upgrade/etc.