### PR TITLE
Allow overriding cmake search path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,9 @@ if (DO_PLATFORM_LINUX)
     # (Enable --trace-expand in cmake and look at lines from boost_headers-config.cmake and its callers.)
     # Workaround: force cmake to look in "/usr" since the /lib and /bin paths are either
     # not relevant for our usage or they are symlinks to /usr/lib and /usr/bin.
-    # set(CMAKE_PREFIX_PATH "/usr")
+    if (NOT CMAKE_PREFIX_PATH)
+        set(CMAKE_PREFIX_PATH "/usr")
+    endif () 
 endif (DO_PLATFORM_LINUX)
 
 if (DO_PLATFORM_WINDOWS AND DO_INCLUDE_SDK)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ if (DO_PLATFORM_LINUX)
     # (Enable --trace-expand in cmake and look at lines from boost_headers-config.cmake and its callers.)
     # Workaround: force cmake to look in "/usr" since the /lib and /bin paths are either
     # not relevant for our usage or they are symlinks to /usr/lib and /usr/bin.
-    set(CMAKE_PREFIX_PATH "/usr")
+    # set(CMAKE_PREFIX_PATH "/usr")
 endif (DO_PLATFORM_LINUX)
 
 if (DO_PLATFORM_WINDOWS AND DO_INCLUDE_SDK)

--- a/build/build.py
+++ b/build/build.py
@@ -98,6 +98,10 @@ class LinuxArgParser(ArgParserBase):
             '--build-for-snap', dest='build_for_snap', action='store_true',
             help='Only build components and features those required for the Ubuntu Core snap'
         )
+        self.parser.add_argument(
+            '--install-prefix', dest='install_prefix', type=str,
+            help='Install prefix to pass to CMake'
+        )
 
         '''Agent only'''
         self.parser.add_argument(
@@ -417,6 +421,7 @@ class LinuxBuildRunner(BuildRunnerBase):
 
         self.static_analysis = self.script_args.static_analysis
         self.build_for_snap = self.script_args.build_for_snap
+        self.install_prefix = self.script_args.install_prefix
 
     @property
     def platform(self):
@@ -443,6 +448,11 @@ class LinuxBuildRunner(BuildRunnerBase):
 
         if self.build_for_snap:
             generate_options.extend(["-DDO_BUILD_FOR_SNAP=1"])
+
+        if self.install_prefix:
+            generate_options.extend(["-DCMAKE_PREFIX_PATH={}".format(self.install_prefix)])
+        else:
+            generate_options.extend(["-DCMAKE_PREFIX_PATH=/usr"])
 
         return generate_options
 

--- a/build/build.py
+++ b/build/build.py
@@ -99,8 +99,8 @@ class LinuxArgParser(ArgParserBase):
             help='Only build components and features those required for the Ubuntu Core snap'
         )
         self.parser.add_argument(
-            '--install-prefix', dest='install_prefix', type=str,
-            help='Install prefix to pass to CMake'
+            '--search-prefix', dest='search_prefix', type=str,
+            help='search prefix to pass to CMake'
         )
 
         '''Agent only'''
@@ -421,7 +421,7 @@ class LinuxBuildRunner(BuildRunnerBase):
 
         self.static_analysis = self.script_args.static_analysis
         self.build_for_snap = self.script_args.build_for_snap
-        self.install_prefix = self.script_args.install_prefix
+        self.search_prefix = self.script_args.search_prefix
 
     @property
     def platform(self):
@@ -449,10 +449,8 @@ class LinuxBuildRunner(BuildRunnerBase):
         if self.build_for_snap:
             generate_options.extend(["-DDO_BUILD_FOR_SNAP=1"])
 
-        if self.install_prefix:
-            generate_options.extend(["-DCMAKE_PREFIX_PATH={}".format(self.install_prefix)])
-        else:
-            generate_options.extend(["-DCMAKE_PREFIX_PATH=/usr"])
+        if self.search_prefix:
+            generate_options.extend(["-DCMAKE_PREFIX_PATH={}".format(self.search_prefix)])
 
         return generate_options
 


### PR DESCRIPTION
[TASK 42848937](https://microsoft.visualstudio.com/OS/_workitems/edit/42848937)

Why is this change being made?
To add Support for SDK build and installation in the Delivery Optimization Snap

What is being changed?
Snapcraft yaml file to properly build and install the sdk in the correct folders

How was the change tested?
Checking if the libdeliveryoptimization file was in the install folder