### PR TITLE
Replace boost::filesystem usage with std::filesystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,10 +17,6 @@ option (DO_INCLUDE_SDK "Build subproject sdk-cpp" OFF)
 option (DO_BUILD_TESTS "Set DO_BUILD_TESTS to OFF to skip building tests." ON)
 option (DO_BUILD_FOR_SNAP "Enable DO Snap build option" OFF)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
 # Get verbose output from cmake generation and build steps
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
@@ -62,6 +58,15 @@ else()
     message(FATAL_ERROR "Unknown platform for client")
 endif()
 
+if (DO_INCLUDE_SDK AND DO_PLATFORM_WINDOWS)
+    # Edge build is not ready to move up to C++17 yet.
+    set(CMAKE_CXX_STANDARD 14)
+else ()
+    set(CMAKE_CXX_STANDARD 17)
+endif ()
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 # PIC (Position Independent Code) ensures .a files can be linked to executables that have PIE enabled
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
@@ -85,7 +90,7 @@ if (DO_PLATFORM_LINUX)
     # not relevant for our usage or they are symlinks to /usr/lib and /usr/bin.
     if (NOT CMAKE_PREFIX_PATH)
         set(CMAKE_PREFIX_PATH "/usr")
-    endif () 
+    endif ()
 endif (DO_PLATFORM_LINUX)
 
 if (DO_PLATFORM_WINDOWS AND DO_INCLUDE_SDK)

--- a/build/scripts/bootstrap.sh
+++ b/build/scripts/bootstrap.sh
@@ -69,7 +69,7 @@ function installBuildDependencies
         apt-get install -y make build-essential g++ gdb gdbserver gcc git wget
         apt-get install -y python3 ninja-build
         apt-get install -y cmake libmsgsl-dev
-        apt-get install -y libboost-system-dev libboost-filesystem-dev libboost-program-options-dev
+        apt-get install -y libboost-program-options-dev
         apt-get install -y libproxy-dev libssl-dev uuid-dev libcurl4-openssl-dev
 
         rm -rf /tmp/gtest

--- a/build/scripts/install-vcpkg-deps.ps1
+++ b/build/scripts/install-vcpkg-deps.ps1
@@ -13,5 +13,4 @@ git checkout 2021.05.12
 .\vcpkg integrate install
 .\vcpkg update
 .\vcpkg install gtest:x64-windows
-.\vcpkg install boost-filesystem:x64-windows
 .\vcpkg install boost-program-options:x64-windows

--- a/build/scripts/install-vcpkg-deps.sh
+++ b/build/scripts/install-vcpkg-deps.sh
@@ -17,9 +17,6 @@ git checkout 2021.05.12
 ./vcpkg integrate install
 
 ./vcpkg install ms-gsl
-./vcpkg install boost-log
-./vcpkg install boost-beast
-./vcpkg install boost-iostreams
 ./vcpkg install boost-uuid
 ./vcpkg install boost-program-options
 ./vcpkg install gtest

--- a/client-lite/CMakeLists.txt
+++ b/client-lite/CMakeLists.txt
@@ -9,8 +9,6 @@ project (${DOSVC_BIN_NAME} VERSION 1.0.0)
 
 option (DO_PROXY_SUPPORT "Set DO_PROXY_SUPPORT to OFF to turn off proxy support for downloads and thus remove dependency on libproxy." ON)
 
-add_definitions(-DBOOST_ALL_DYN_LINK=1)
-
 # -Wno-noexcept-type, the offending function is SetResultLoggingCallback, this warning is fixed in C++17 because exception specification
 # is part of a function type. Since the offending function is not public when compiled into docs_common just add the compiler flag here
 # to disable the warning.
@@ -29,7 +27,6 @@ function (target_link_dl_lib target)
 endfunction ()
 
 # Include external libraries here:
-find_package(Boost COMPONENTS filesystem REQUIRED)
 find_package(CURL REQUIRED)
 # g++ requires explicit specification of the thread library to be used
 find_package(Threads REQUIRED)
@@ -124,7 +121,6 @@ add_platform_interface_definitions(${DOSVC_BIN_NAME})
 target_include_directories(${DOSVC_BIN_NAME} PRIVATE ${docs_common_includes})
 target_link_libraries(${DOSVC_BIN_NAME}
     docs_common
-    ${Boost_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
 )
 

--- a/client-lite/src/ipc/rest_port_advertiser.h
+++ b/client-lite/src/ipc/rest_port_advertiser.h
@@ -7,7 +7,7 @@
 #include <fcntl.h>  // open, write
 #include <unistd.h> // getpid
 #include <sstream>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <gsl/gsl_util>
 #include "do_persistence.h"
 #include "error_macros.h"
@@ -60,13 +60,13 @@ private:
     void _DeleteOlderPortFiles() try
     {
         auto& runtimeDirectory = docli::GetRuntimeDirectory();
-        for (boost::filesystem::directory_iterator itr(runtimeDirectory); itr != boost::filesystem::directory_iterator(); ++itr)
+        for (std::filesystem::directory_iterator itr(runtimeDirectory); itr != std::filesystem::directory_iterator(); ++itr)
         {
             auto& dirEntry = itr->path();
             if (dirEntry.filename().string().find(_restPortFileNamePrefix) != std::string::npos)
             {
-                boost::system::error_code ec;
-                boost::filesystem::remove(dirEntry, ec);
+                std::error_code ec;
+                std::filesystem::remove(dirEntry, ec);
                 if (ec)
                 {
                     DoLogWarning("Failed to delete old port file (%d, %s) %s", ec.value(), ec.message().data(), dirEntry.string().data());

--- a/client-lite/src/util/do_json_parser.cpp
+++ b/client-lite/src/util/do_json_parser.cpp
@@ -4,7 +4,7 @@
 #include "do_common.h"
 #include "do_json_parser.h"
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <boost/property_tree/json_parser.hpp>
 
 std::chrono::seconds JsonParser::RefreshInterval = std::chrono::seconds(60);
@@ -13,7 +13,7 @@ std::chrono::seconds JsonParser::RefreshInterval = std::chrono::seconds(60);
 JsonParser::JsonParser(const std::string& jsonFilePath, bool alwaysCreateFile) :
     _jsonFilePath(jsonFilePath)
 {
-    if (alwaysCreateFile && !(boost::filesystem::exists(_jsonFilePath)))
+    if (alwaysCreateFile && !(std::filesystem::exists(_jsonFilePath)))
     {
         DoLogInfo("json file not found at %s, creating file", _jsonFilePath.data());
         boost::property_tree::ptree json;
@@ -33,7 +33,7 @@ void JsonParser::_TryRefresh(bool force)
             return;
     }
 
-    if (boost::filesystem::exists(_jsonFilePath))
+    if (std::filesystem::exists(_jsonFilePath))
     {
         try
         {

--- a/client-lite/src/util/proc_launch_helper.h
+++ b/client-lite/src/util/proc_launch_helper.h
@@ -9,7 +9,7 @@
 #include <pwd.h>
 #include <grp.h>
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #include "do_common.h"
 #include "do_persistence.h"
@@ -54,11 +54,11 @@ inline void SetDOPathPermissions(const std::string& path, mode_t mode)
 
 inline void InitializePath(const std::string& path, mode_t mode = 0) try
 {
-    boost::filesystem::path dirPath(path);
-    if (!boost::filesystem::exists(dirPath))
+    std::filesystem::path dirPath(path);
+    if (!std::filesystem::exists(dirPath))
     {
         DoLogInfo("Creating directories for %s", path.c_str());
-        boost::filesystem::create_directories(dirPath);
+        std::filesystem::create_directories(dirPath);
 
         if (mode != 0)
         {

--- a/client-lite/test/CMakeLists.txt
+++ b/client-lite/test/CMakeLists.txt
@@ -1,11 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# Unit tests for DOCS
-
-# Only need program_options here but have to include others required by docs_common.
-# TODO: docs_common should declare what it needs via target_link_libraries(PUBLIC).
-find_package(Boost COMPONENTS filesystem program_options REQUIRED)
+find_package(Boost COMPONENTS program_options REQUIRED)
 find_package(GTest REQUIRED)
 
 file (GLOB files_docs_tests
@@ -15,7 +11,6 @@ add_platform_interface_definitions(deliveryoptimization-agent-tests)
 target_link_libraries(deliveryoptimization-agent-tests
     docs_common
     dotestutil
-    stdc++fs
     ${Boost_LIBRARIES}
     GTest::GTest
 )

--- a/client-lite/test/do_log_tests.cpp
+++ b/client-lite/test/do_log_tests.cpp
@@ -26,12 +26,12 @@ TEST_F(DOLoggerTests, BasicWriteToFile)
     DOLog::Close();
 
     UINT nLogFilesFound = 0;
-    for (cppfs::recursive_directory_iterator itr(g_testTempDir); itr != cppfs::recursive_directory_iterator{}; ++itr)
+    for (std::filesystem::recursive_directory_iterator itr(g_testTempDir); itr != std::filesystem::recursive_directory_iterator{}; ++itr)
     {
         ++nLogFilesFound;
         const auto filePath = itr->path();
         ASSERT_NE(strstr(filePath.c_str(), "do-agent."), nullptr);
-        ASSERT_GT(cppfs::file_size(filePath), 0);
+        ASSERT_GT(std::filesystem::file_size(filePath), 0);
 
         std::ifstream fs;
         fs.open(filePath.string());

--- a/client-lite/test/docs_tests.cpp
+++ b/client-lite/test/docs_tests.cpp
@@ -6,7 +6,7 @@
 #include <boost/program_options.hpp>
 #include "test_data.h"
 
-const cppfs::path g_testTempDir = "/tmp/docs_test_scratch";
+const std::filesystem::path g_testTempDir = "/tmp/docs_test_scratch";
 
 int main(int argc, char** argv)
 {
@@ -15,7 +15,7 @@ int main(int argc, char** argv)
     // TODO(shishirb) enable console only logging
 
     std::error_code ec;
-    cppfs::create_directories(g_testTempDir, ec);
+    std::filesystem::create_directories(g_testTempDir, ec);
     if (ec)
     {
         printf("Failed to create test dir: %s\n", g_testTempDir.string().data());

--- a/client-lite/test/download_manager_tests.cpp
+++ b/client-lite/test/download_manager_tests.cpp
@@ -136,7 +136,7 @@ TEST_F(DownloadManagerTests, FileDownloadFatal404)
     ASSERT_EQ(status.BytesTotal, 0);
     VerifyError(status, HTTP_E_STATUS_NOT_FOUND);
     VerifyDownloadHttpStatus(*DownloadForId(manager, id), 404);
-    ASSERT_TRUE(cppfs::exists(destFile));
+    ASSERT_TRUE(std::filesystem::exists(destFile));
     manager.AbortDownload(id);
     VerifyFileNotFound(destFile);
 }

--- a/client-lite/test/json_parser_tests.cpp
+++ b/client-lite/test/json_parser_tests.cpp
@@ -12,7 +12,7 @@
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
-const cppfs::path g_jsonTestFilePath = g_testTempDir / "docs_config.json";
+const std::filesystem::path g_jsonTestFilePath = g_testTempDir / "docs_config.json";
 
 const std::map<std::string, std::string> g_testData =
 {
@@ -70,9 +70,9 @@ public:
     void SetUp() override
     {
         JsonParser::RefreshInterval = std::chrono::seconds(10); // for faster test times
-        if (cppfs::exists(g_jsonTestFilePath))
+        if (std::filesystem::exists(g_jsonTestFilePath))
         {
-            cppfs::remove(g_jsonTestFilePath);
+            std::filesystem::remove(g_jsonTestFilePath);
         }
     }
 };
@@ -111,7 +111,7 @@ TEST_F(JsonParserTests, ReadConfigsWithUpdates)
     VerifyItemFound(reader, "newkey", "newvalue");
 
     // Delete config file and verify
-    cppfs::remove(g_jsonTestFilePath);
+    std::filesystem::remove(g_jsonTestFilePath);
     VerifyItemFound(reader, "newkey", "newvalue"); // within refresh interval
     VerifyTestData(reader, true);
 
@@ -122,9 +122,9 @@ TEST_F(JsonParserTests, ReadConfigsWithUpdates)
 
 TEST_F(JsonParserTests, ReadConfigsWithFileCreatedLater)
 {
-    if (cppfs::exists(g_jsonTestFilePath))
+    if (std::filesystem::exists(g_jsonTestFilePath))
     {
-        cppfs::remove(g_jsonTestFilePath);
+        std::filesystem::remove(g_jsonTestFilePath);
     }
 
     JsonParser reader(g_jsonTestFilePath);

--- a/client-lite/test/mcc_manager.tests.cpp
+++ b/client-lite/test/mcc_manager.tests.cpp
@@ -28,13 +28,13 @@ using btcp_t = boost::asio::ip::tcp;
 #define TEST_MOCK_MCC_HOST   "10.130.48.179"
 #define TEST_MOCK_MCC_HOST2  "10.130.48.180"
 
-const cppfs::path g_adminConfigFilePath = g_testTempDir / "admin-config.json";
-const cppfs::path g_sdkConfigFilePath = g_testTempDir / "sdk-config.json";
+const std::filesystem::path g_adminConfigFilePath = g_testTempDir / "admin-config.json";
+const std::filesystem::path g_sdkConfigFilePath = g_testTempDir / "sdk-config.json";
 
 static void SetIoTConnectionString(const char* connectionString)
 {
     boost::property_tree::ptree json;
-    if (cppfs::exists(g_sdkConfigFilePath))
+    if (std::filesystem::exists(g_sdkConfigFilePath))
     {
         boost::property_tree::read_json(g_sdkConfigFilePath, json);
     }
@@ -45,7 +45,7 @@ static void SetIoTConnectionString(const char* connectionString)
 static void SetDOCacheHostConfig(const char* server)
 {
     boost::property_tree::ptree json;
-    if (cppfs::exists(g_adminConfigFilePath))
+    if (std::filesystem::exists(g_adminConfigFilePath))
     {
         boost::property_tree::read_json(g_adminConfigFilePath, json);
     }
@@ -56,7 +56,7 @@ static void SetDOCacheHostConfig(const char* server)
 static void SetFallbackDelayConfig(std::chrono::seconds delay)
 {
     boost::property_tree::ptree json;
-    if (cppfs::exists(g_adminConfigFilePath))
+    if (std::filesystem::exists(g_adminConfigFilePath))
     {
         boost::property_tree::read_json(g_adminConfigFilePath, json);
     }
@@ -71,13 +71,13 @@ public:
     {
         ClearTestTempDir();
 
-        if (cppfs::exists(g_adminConfigFilePath))
+        if (std::filesystem::exists(g_adminConfigFilePath))
         {
-            cppfs::remove(g_adminConfigFilePath);
+            std::filesystem::remove(g_adminConfigFilePath);
         }
-        if (cppfs::exists(g_sdkConfigFilePath))
+        if (std::filesystem::exists(g_sdkConfigFilePath))
         {
-            cppfs::remove(g_sdkConfigFilePath);
+            std::filesystem::remove(g_sdkConfigFilePath);
         }
     }
 
@@ -107,7 +107,7 @@ TEST_F(MCCManagerTests, ParseIoTConnectionString)
     _VerifyExpectedCacheHost(TEST_MOCK_MCC_HOST);
 
     // No gateway specified
-    cppfs::remove(g_sdkConfigFilePath);
+    std::filesystem::remove(g_sdkConfigFilePath);
     _VerifyExpectedCacheHost("");
 }
 
@@ -117,7 +117,7 @@ TEST_F(MCCManagerTests, AdminConfigOverride)
     SetDOCacheHostConfig(TEST_MOCK_MCC_HOST2);
     _VerifyExpectedCacheHost(TEST_MOCK_MCC_HOST2);
 
-    cppfs::remove(g_adminConfigFilePath);
+    std::filesystem::remove(g_adminConfigFilePath);
     _VerifyExpectedCacheHost(TEST_MOCK_MCC_HOST);
 }
 
@@ -127,7 +127,7 @@ TEST_F(MCCManagerTests, AdminConfigEmptyString)
     SetDOCacheHostConfig("");
     _VerifyExpectedCacheHost("");
 
-    cppfs::remove(g_adminConfigFilePath);
+    std::filesystem::remove(g_adminConfigFilePath);
     _VerifyExpectedCacheHost(TEST_MOCK_MCC_HOST);
 }
 

--- a/client-lite/test/test_common.h
+++ b/client-lite/test/test_common.h
@@ -6,19 +6,17 @@
 #include "do_common.h"
 
 #include <chrono>
-#include <experimental/filesystem>
+#include <filesystem>
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
-namespace cppfs = std::experimental::filesystem;
-
-extern const cppfs::path g_testTempDir;
+extern const std::filesystem::path g_testTempDir;
 
 inline void ClearTestTempDir()
 {
-    if (cppfs::exists(g_testTempDir))
+    if (std::filesystem::exists(g_testTempDir))
     {
-        cppfs::remove_all(g_testTempDir);
+        std::filesystem::remove_all(g_testTempDir);
     }
-    cppfs::create_directories(g_testTempDir);
+    std::filesystem::create_directories(g_testTempDir);
 }

--- a/client-lite/test/test_verifiers.h
+++ b/client-lite/test/test_verifiers.h
@@ -10,12 +10,12 @@
 
 inline void VerifyFileSize(const std::string& path, UINT64 cbExpectedSize)
 {
-    ASSERT_EQ(cppfs::file_size(path), cbExpectedSize) << "File size check: " << path;
+    ASSERT_EQ(std::filesystem::file_size(path), cbExpectedSize) << "File size check: " << path;
 }
 
 inline void VerifyFileNotFound(const std::string& path)
 {
-    ASSERT_FALSE(cppfs::exists(path)) << "File absent check: " << path;
+    ASSERT_FALSE(std::filesystem::exists(path)) << "File absent check: " << path;
 }
 
 inline void VerifyNoError(const DownloadStatus& status)

--- a/sdk-cpp/CMakeLists.txt
+++ b/sdk-cpp/CMakeLists.txt
@@ -3,14 +3,6 @@
 
 project (deliveryoptimization_sdk VERSION 1.0.0)
 
-if (DO_PLATFORM_LINUX OR DO_PLATFORM_MAC)
-    message("DO configured to use shared Boost libraries")
-    add_definitions(-DBOOST_ALL_DYN_LINK=1)
-
-    # Include external libraries here
-    find_package(Boost COMPONENTS filesystem REQUIRED)
-endif()
-
 if (DO_PLATFORM_LINUX)
     fixup_compile_options_for_arm()
 endif()
@@ -65,10 +57,6 @@ if(DO_PLATFORM_LINUX)
         dohttp
     )
 
-    set(sdk_public_linked_libs
-        ${Boost_LIBRARIES}
-    )
-
     strip_symbols(${DO_SDK_LIB_NAME})
 
 elseif(DO_PLATFORM_MAC)
@@ -90,9 +78,6 @@ elseif(DO_PLATFORM_MAC)
         dohttp
     )
 
-    set(sdk_public_linked_libs
-        ${Boost_LIBRARIES}
-    )
 elseif(DO_PLATFORM_WINDOWS)
     file(GLOB sdk_source
         ${sdk_source_common}
@@ -134,8 +119,6 @@ endif ()
 add_platform_interface_definitions(${DO_SDK_LIB_NAME})
 
 target_link_libraries(${DO_SDK_LIB_NAME}
-    PUBLIC
-        ${sdk_public_linked_libs}
     PRIVATE
         ${sdk_private_linked_libs}
 )

--- a/sdk-cpp/build/cmake/deliveryoptimization_sdk-config.cmake
+++ b/sdk-cpp/build/cmake/deliveryoptimization_sdk-config.cmake
@@ -1,11 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-include(CMakeFindDependencyMacro)
-if (${CMAKE_VERSION} VERSION_GREATER "3.9.0")
-    find_dependency(Boost COMPONENTS filesystem system)
-else ()
-    # Old cmake versions do not support extra args to find_dependency
-    find_dependency(Boost)
-endif ()
 include("${CMAKE_CURRENT_LIST_DIR}/deliveryoptimization_sdk-targets.cmake")

--- a/sdk-cpp/src/internal/rest/do_config_internal.cpp
+++ b/sdk-cpp/src/internal/rest/do_config_internal.cpp
@@ -8,7 +8,7 @@
 #include <string>
 
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
@@ -31,9 +31,9 @@ static int WriteIoTConnectionStringToConfigFile(const char* value) noexcept
     int returnValue = 0;
     // ptree's exceptions do not provide an error code, and SDK has no logging of its own.
     // Return specific errors as a workaround.
-    boost::filesystem::path filePath{microsoft::deliveryoptimization::details::GetConfigFilePath()};
-    boost::system::error_code ec;
-    if (boost::filesystem::exists(filePath.parent_path(), ec))
+    std::filesystem::path filePath{microsoft::deliveryoptimization::details::GetConfigFilePath()};
+    std::error_code ec;
+    if (std::filesystem::exists(filePath.parent_path(), ec))
     {
         try
         {
@@ -74,10 +74,10 @@ static std::string GetSdkVersion()
     return msdoutil::ComponentVersion(false);
 }
 
-static std::string GetBinaryVersion(const boost::filesystem::path& binaryFilePath)
+static std::string GetBinaryVersion(const std::filesystem::path& binaryFilePath)
 {
     std::string version;
-    if (boost::filesystem::exists(binaryFilePath))
+    if (std::filesystem::exists(binaryFilePath))
     {
         FILE* fp = nullptr;
         try
@@ -118,7 +118,7 @@ static void AppendBinaryVersion(const char* binFileName, std::stringstream& allV
     // to cover special cases (for example, installed not via our deb/rpm packages).
     // We do not use bp::search_path() in order to avoid executing a malicious program with the
     // same name and which appears earlier in the PATH environment variable.
-    boost::filesystem::path binFilePath("/usr/local/bin");
+    std::filesystem::path binFilePath("/usr/local/bin");
     binFilePath /= binFileName;
     std::string version = GetBinaryVersion(binFilePath);
     if (version.empty())

--- a/sdk-cpp/src/internal/rest/util/do_port_finder.cpp
+++ b/sdk-cpp/src/internal/rest/util/do_port_finder.cpp
@@ -2,10 +2,10 @@
 
 #include <chrono>
 #include <ctime>
+#include <filesystem>
+#include <fstream>
 #include <string>
 #include <thread>
-
-#include <boost/filesystem.hpp>
 
 #include "do_errors.h"
 #include "do_error_helpers.h"
@@ -25,19 +25,19 @@ namespace details
 static std::string g_DiscoverDOPort()
 {
     const std::string runtimeDirectory = GetRuntimeDirectory();
-    if (!boost::filesystem::exists(runtimeDirectory))
+    if (!std::filesystem::exists(runtimeDirectory))
     {
         return std::string();
     }
 
-    boost::filesystem::path mostRecentFile("");
-    std::time_t mostRecentTime = 0;
-    for (boost::filesystem::directory_iterator itr(runtimeDirectory); itr != boost::filesystem::directory_iterator(); ++itr)
+    std::filesystem::path mostRecentFile("");
+    auto mostRecentTime = std::filesystem::file_time_type::min();
+    for (std::filesystem::directory_iterator itr(runtimeDirectory); itr != std::filesystem::directory_iterator(); ++itr)
     {
-        const boost::filesystem::path& dirEntry = itr->path();
+        const std::filesystem::path& dirEntry = itr->path();
         if (dirEntry.filename().string().find("restport") != std::string::npos)
         {
-            std::time_t currTime = boost::filesystem::last_write_time(dirEntry);
+            auto currTime = std::filesystem::last_write_time(dirEntry);
             if (currTime > mostRecentTime)
             {
                 mostRecentTime = currTime;

--- a/sdk-cpp/tests/CMakeLists.txt
+++ b/sdk-cpp/tests/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 ## Tests for DO SDK
 
-find_package(Boost COMPONENTS filesystem program_options REQUIRED)
+find_package(Boost COMPONENTS program_options REQUIRED)
 find_package(GTest REQUIRED)
 
 set(sdk_tests_linked_libs_common
@@ -28,10 +28,6 @@ if(DO_PLATFORM_LINUX)
     set(dosdkcpp_private_includes
         "../src/internal/rest"
         "../src/internal/rest/util"
-    )
-
-    set(sdk_tests_linked_libs
-        stdc++fs
     )
 
     set(test_source_private
@@ -77,9 +73,9 @@ target_include_directories(deliveryoptimization-sdk-tests
     PRIVATE
         ${dosdkcpp_private_includes}
         ${dosdkcpp_private_includes_common}
+        ${Boost_INCLUDE_DIRS}
 )
 
 target_link_libraries(deliveryoptimization-sdk-tests
-    ${sdk_tests_linked_libs}
     ${sdk_tests_linked_libs_common}
 )

--- a/sdk-cpp/tests/download_properties_tests.cpp
+++ b/sdk-cpp/tests/download_properties_tests.cpp
@@ -22,7 +22,7 @@ public:
     void SetUp() override
     {
         TestHelpers::CleanTestDir();
-        ASSERT_FALSE(boost::filesystem::exists(g_tmpFileName));
+        ASSERT_FALSE(std::filesystem::exists(g_tmpFileName));
     }
     void TearDown() override
     {
@@ -62,7 +62,7 @@ TEST_F(DownloadPropertyTests, SmallDownloadSetCallerNameTest)
     ASSERT_EQ(strCallerName, outCallerName);
 
     simpleDownload->start_and_wait_until_completion();
-    ASSERT_TRUE(boost::filesystem::exists(g_tmpFileName));
+    ASSERT_TRUE(std::filesystem::exists(g_tmpFileName));
 }
 
 TEST_F(DownloadPropertyTests, SmallDownloadWithPhfDigestandCvTest)
@@ -83,7 +83,7 @@ TEST_F(DownloadPropertyTests, SmallDownloadWithPhfDigestandCvTest)
 
     ASSERT_EQ(simpleDownload->start_and_wait_until_completion().value(), 0);
 
-    ASSERT_TRUE(boost::filesystem::exists(g_tmpFileName));
+    ASSERT_TRUE(std::filesystem::exists(g_tmpFileName));
 }
 
 TEST_F(DownloadPropertyTests, InvalidPhfDigestTest)
@@ -102,7 +102,7 @@ TEST_F(DownloadPropertyTests, SmallDownloadWithCustomHeaders)
     auto simpleDownload = msdot::download::make(g_smallFileUrl, g_tmpFileName);
     simpleDownload->set_property(msdo::download_property::http_custom_headers, "XCustom1=someData\nXCustom2=moreData\n");
     simpleDownload->start_and_wait_until_completion();
-    ASSERT_TRUE(boost::filesystem::exists(g_tmpFileName));
+    ASSERT_TRUE(std::filesystem::exists(g_tmpFileName));
 }
 
 TEST_F(DownloadPropertyTests, CallbackTestUseDownload)

--- a/sdk-cpp/tests/download_tests_common.cpp
+++ b/sdk-cpp/tests/download_tests_common.cpp
@@ -11,7 +11,7 @@
 #include <signal.h>
 #include <sys/types.h>
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #include "do_download.h"
 #include "do_download_status.h"
@@ -80,21 +80,21 @@ TEST_F(DownloadTests, SimpleDownloadTest)
     ASSERT_EQ(status.bytes_total(), g_smallFileSizeBytes);
 
     simpleDownload->finalize();
-    ASSERT_EQ(boost::filesystem::file_size(boost::filesystem::path(g_tmpFileName)), g_smallFileSizeBytes);
+    ASSERT_EQ(std::filesystem::file_size(std::filesystem::path(g_tmpFileName)), g_smallFileSizeBytes);
 }
 
 TEST_F(DownloadTests, SimpleBlockingDownloadTest)
 {
-    ASSERT_FALSE(boost::filesystem::exists(g_tmpFileName));
+    ASSERT_FALSE(std::filesystem::exists(g_tmpFileName));
     msdot::download::download_url_to_path(g_smallFileUrl, g_tmpFileName);
-    ASSERT_TRUE(boost::filesystem::exists(g_tmpFileName));
-    ASSERT_EQ(boost::filesystem::file_size(boost::filesystem::path(g_tmpFileName)), g_smallFileSizeBytes);
+    ASSERT_TRUE(std::filesystem::exists(g_tmpFileName));
+    ASSERT_EQ(std::filesystem::file_size(std::filesystem::path(g_tmpFileName)), g_smallFileSizeBytes);
 }
 
 TEST_F(DownloadTests, CancelBlockingDownloadTest)
 {
     std::atomic_bool cancelToken { false };
-    ASSERT_FALSE(boost::filesystem::exists(g_tmpFileName));
+    ASSERT_FALSE(std::filesystem::exists(g_tmpFileName));
     std::thread downloadThread([&]()
     {
         try
@@ -110,7 +110,7 @@ TEST_F(DownloadTests, CancelBlockingDownloadTest)
     std::this_thread::sleep_for(1s);
     cancelToken = true;
     downloadThread.join();
-    ASSERT_FALSE(boost::filesystem::exists(g_tmpFileName));
+    ASSERT_FALSE(std::filesystem::exists(g_tmpFileName));
 }
 
 TEST_F(DownloadTests, BlockingDownloadTimeout)
@@ -128,13 +128,13 @@ TEST_F(DownloadTests, BlockingDownloadTimeout)
         ASSERT_GE(elapsedTime, std::chrono::seconds(2));
         ASSERT_LE(elapsedTime, std::chrono::seconds(5));
     }
-    ASSERT_FALSE(boost::filesystem::exists(g_tmpFileName));
+    ASSERT_FALSE(std::filesystem::exists(g_tmpFileName));
 }
 
 // Note: This test takes a long time to execute due to 30 retry intervals from DOCS
 TEST_F(DownloadTests, SimpleDownloadTest_With404Url)
 {
-    ASSERT_FALSE(boost::filesystem::exists(g_tmpFileName));
+    ASSERT_FALSE(std::filesystem::exists(g_tmpFileName));
 
     try
     {
@@ -165,13 +165,13 @@ TEST_F(DownloadTests, SimpleDownloadTest_WithMalformedPath)
 #elif defined(DO_INTERFACE_REST)
         ASSERT_EQ(e.error_code().value(), DO_ERROR_FROM_SYSTEM_ERROR(ENOENT));
 #endif
-        ASSERT_FALSE(boost::filesystem::exists(g_tmpFileName));
+        ASSERT_FALSE(std::filesystem::exists(g_tmpFileName));
     }
 }
 
 TEST_F(DownloadTests, SimpleDownloadTest_With404UrlAndMalformedPath)
 {
-    ASSERT_FALSE(boost::filesystem::exists(g_tmpFileName));
+    ASSERT_FALSE(std::filesystem::exists(g_tmpFileName));
 
     try
     {
@@ -189,7 +189,7 @@ TEST_F(DownloadTests, SimpleDownloadTest_With404UrlAndMalformedPath)
 #elif defined(DO_INTERFACE_REST)
         ASSERT_EQ(e.error_code().value(), DO_ERROR_FROM_SYSTEM_ERROR(ENOENT));
 #endif
-        ASSERT_FALSE(boost::filesystem::exists(g_tmpFileName));
+        ASSERT_FALSE(std::filesystem::exists(g_tmpFileName));
     }
     catch (const std::exception& se)
     {
@@ -200,7 +200,7 @@ TEST_F(DownloadTests, SimpleDownloadTest_With404UrlAndMalformedPath)
 
 TEST_F(DownloadTests, Download1PausedDownload2SameDestTest)
 {
-    ASSERT_FALSE(boost::filesystem::exists(g_tmpFileName));
+    ASSERT_FALSE(std::filesystem::exists(g_tmpFileName));
     auto simpleDownload = msdot::download::make(g_largeFileUrl, g_tmpFileName);
     msdo::download_status status = simpleDownload->get_status();
     ASSERT_EQ(status.state(), msdo::download_state::created);
@@ -214,7 +214,7 @@ TEST_F(DownloadTests, Download1PausedDownload2SameDestTest)
 
 #ifdef DO_CLIENT_AGENT
     // Only DO Agent creates the output file upon calling start()
-    ASSERT_TRUE(boost::filesystem::exists(g_tmpFileName)) << "Verify output file created for first download";
+    ASSERT_TRUE(std::filesystem::exists(g_tmpFileName)) << "Verify output file created for first download";
 
     // DO Agent does not support downloading to an already existing path (yet?).
     // Verify second download fails and the first download resumes successfully.
@@ -229,23 +229,23 @@ TEST_F(DownloadTests, Download1PausedDownload2SameDestTest)
        ASSERT_EQ(e.error_code().value(), DO_ERROR_FROM_SYSTEM_ERROR(EEXIST));
     }
     simpleDownload2->abort();
-    ASSERT_TRUE(boost::filesystem::exists(g_tmpFileName)); // not deleted, the earlier download is still active
+    ASSERT_TRUE(std::filesystem::exists(g_tmpFileName)); // not deleted, the earlier download is still active
 
     simpleDownload->abort();
-    ASSERT_FALSE(boost::filesystem::exists(g_tmpFileName));
+    ASSERT_FALSE(std::filesystem::exists(g_tmpFileName));
 
     // download2 should now succeed
     simpleDownload2 = msdot::download::make(g_smallFileUrl, g_tmpFileName);
     simpleDownload2->start();
     WaitForDownloadCompletion(*simpleDownload2);
-    ASSERT_EQ(boost::filesystem::file_size(g_tmpFileName), g_smallFileSizeBytes);
+    ASSERT_EQ(std::filesystem::file_size(g_tmpFileName), g_smallFileSizeBytes);
 
 #elif defined(DO_CLIENT_DOSVC)
     // DoSvc does support downloading to an already existing path via
     // aborting the first download. Verify this and that the second download succeeds.
 
     msdo::test::download::download_url_to_path(g_smallFileUrl, g_tmpFileName);
-    ASSERT_EQ(boost::filesystem::file_size(boost::filesystem::path(g_tmpFileName)), g_smallFileSizeBytes);
+    ASSERT_EQ(std::filesystem::file_size(std::filesystem::path(g_tmpFileName)), g_smallFileSizeBytes);
 
     status = simpleDownload->get_status();
     ASSERT_EQ(status.state(), msdo::download_state::aborted);
@@ -257,7 +257,7 @@ TEST_F(DownloadTests, Download1PausedDownload2SameDestTest)
 
 TEST_F(DownloadTests, Download1PausedDownload2SameFileDownload1Resume)
 {
-    ASSERT_FALSE(boost::filesystem::exists(g_tmpFileName));
+    ASSERT_FALSE(std::filesystem::exists(g_tmpFileName));
     auto simpleDownload = msdot::download::make(g_largeFileUrl, g_tmpFileName);
     msdo::download_status status = simpleDownload->get_status();
     ASSERT_EQ(status.state(), msdo::download_state::created);
@@ -271,19 +271,19 @@ TEST_F(DownloadTests, Download1PausedDownload2SameFileDownload1Resume)
 
     std::cout << "Downloading the same file with a second download" << std::endl;
     msdot::download::download_url_to_path(g_largeFileUrl, g_tmpFileName2);
-    ASSERT_EQ(boost::filesystem::file_size(boost::filesystem::path(g_tmpFileName2)), g_largeFileSizeBytes);
+    ASSERT_EQ(std::filesystem::file_size(std::filesystem::path(g_tmpFileName2)), g_largeFileSizeBytes);
 
     std::cout << "Resuming and waiting for completion of first download" << std::endl;
     simpleDownload->resume();
     TestHelpers::WaitForState(*simpleDownload, msdo::download_state::transferred, g_largeFileWaitTime);
 
     simpleDownload->finalize();
-    ASSERT_EQ(boost::filesystem::file_size(boost::filesystem::path(g_tmpFileName)), g_largeFileSizeBytes);
+    ASSERT_EQ(std::filesystem::file_size(std::filesystem::path(g_tmpFileName)), g_largeFileSizeBytes);
 }
 
 TEST_F(DownloadTests, Download1NeverStartedDownload2CancelledSameFileTest)
 {
-    ASSERT_FALSE(boost::filesystem::exists(g_tmpFileName));
+    ASSERT_FALSE(std::filesystem::exists(g_tmpFileName));
     auto simpleDownload = msdot::download::make(g_largeFileUrl, g_tmpFileName);
     msdo::download_status status = simpleDownload->get_status();
     ASSERT_EQ(status.state(), msdo::download_state::created);
@@ -298,7 +298,7 @@ TEST_F(DownloadTests, Download1NeverStartedDownload2CancelledSameFileTest)
     {
         ASSERT_EQ(e.error_code().value(), msdo::errc::not_found);
     }
-    ASSERT_FALSE(boost::filesystem::exists(g_tmpFileName));
+    ASSERT_FALSE(std::filesystem::exists(g_tmpFileName));
 }
 
 TEST_F(DownloadTests, ResumeOnAlreadyDownloadedFileTest)
@@ -316,7 +316,7 @@ TEST_F(DownloadTests, ResumeOnAlreadyDownloadedFileTest)
     ASSERT_EQ(status.bytes_total(), g_smallFileSizeBytes);
 
     simpleDownload->finalize();
-    ASSERT_EQ(boost::filesystem::file_size(boost::filesystem::path(g_tmpFileName)), g_smallFileSizeBytes);
+    ASSERT_EQ(std::filesystem::file_size(std::filesystem::path(g_tmpFileName)), g_smallFileSizeBytes);
 
     try
     {
@@ -348,7 +348,7 @@ TEST_F(DownloadTests, CancelDownloadOnCompletedState)
     ASSERT_EQ(status.bytes_total(), g_smallFileSizeBytes);
 
     simpleDownload->finalize();
-    ASSERT_EQ(boost::filesystem::file_size(boost::filesystem::path(g_tmpFileName)), g_smallFileSizeBytes);
+    ASSERT_EQ(std::filesystem::file_size(std::filesystem::path(g_tmpFileName)), g_smallFileSizeBytes);
 
     try
     {
@@ -380,7 +380,7 @@ TEST_F(DownloadTests, CancelDownloadInTransferredState)
 
 #if defined(DO_INTERFACE_REST)
     // On Windows need to finalize in order for file to show up on disk, so exclude check here
-    ASSERT_EQ(boost::filesystem::file_size(boost::filesystem::path(g_tmpFileName)), g_smallFileSizeBytes);
+    ASSERT_EQ(std::filesystem::file_size(std::filesystem::path(g_tmpFileName)), g_smallFileSizeBytes);
 #endif
     try
     {
@@ -422,7 +422,7 @@ static void _PauseResumeTest(bool delayAfterStart = false)
     ASSERT_EQ(status.state(), msdo::download_state::transferred);
     ASSERT_EQ(status.bytes_total(), status.bytes_transferred());
     simpleDownload->finalize();
-    ASSERT_EQ(boost::filesystem::file_size(boost::filesystem::path(g_tmpFileName)), g_largeFileSizeBytes);
+    ASSERT_EQ(std::filesystem::file_size(std::filesystem::path(g_tmpFileName)), g_largeFileSizeBytes);
 }
 
 TEST_F(DownloadTests, PauseResumeTest)
@@ -437,25 +437,25 @@ TEST_F(DownloadTests, PauseResumeTestWithDelayAfterStart)
 
 TEST_F(DownloadTests, MultipleConsecutiveDownloadTest)
 {
-    ASSERT_FALSE(boost::filesystem::exists(g_tmpFileName));
+    ASSERT_FALSE(std::filesystem::exists(g_tmpFileName));
     msdot::download::download_url_to_path(g_smallFileUrl, g_tmpFileName);
-    ASSERT_TRUE(boost::filesystem::exists(g_tmpFileName));
-    ASSERT_EQ(boost::filesystem::file_size(boost::filesystem::path(g_tmpFileName)), g_smallFileSizeBytes);
+    ASSERT_TRUE(std::filesystem::exists(g_tmpFileName));
+    ASSERT_EQ(std::filesystem::file_size(std::filesystem::path(g_tmpFileName)), g_smallFileSizeBytes);
 
-    ASSERT_FALSE(boost::filesystem::exists(g_tmpFileName2));
+    ASSERT_FALSE(std::filesystem::exists(g_tmpFileName2));
     msdot::download::download_url_to_path(g_smallFileUrl, g_tmpFileName2);
-    ASSERT_TRUE(boost::filesystem::exists(g_tmpFileName2));
-    ASSERT_EQ(boost::filesystem::file_size(boost::filesystem::path(g_tmpFileName2)), g_smallFileSizeBytes);
+    ASSERT_TRUE(std::filesystem::exists(g_tmpFileName2));
+    ASSERT_EQ(std::filesystem::file_size(std::filesystem::path(g_tmpFileName2)), g_smallFileSizeBytes);
 
-    ASSERT_FALSE(boost::filesystem::exists(g_tmpFileName3));
+    ASSERT_FALSE(std::filesystem::exists(g_tmpFileName3));
     msdot::download::download_url_to_path(g_smallFileUrl, g_tmpFileName3);
-    ASSERT_TRUE(boost::filesystem::exists(g_tmpFileName3));
-    ASSERT_EQ(boost::filesystem::file_size(boost::filesystem::path(g_tmpFileName3)), g_smallFileSizeBytes);
+    ASSERT_TRUE(std::filesystem::exists(g_tmpFileName3));
+    ASSERT_EQ(std::filesystem::file_size(std::filesystem::path(g_tmpFileName3)), g_smallFileSizeBytes);
 }
 
 TEST_F(DownloadTests, MultipleConcurrentDownloadTest)
 {
-    ASSERT_FALSE(boost::filesystem::exists(g_tmpFileName));
+    ASSERT_FALSE(std::filesystem::exists(g_tmpFileName));
     std::thread downloadThread([&]()
     {
         try
@@ -495,9 +495,9 @@ TEST_F(DownloadTests, MultipleConcurrentDownloadTest)
     downloadThread2.join();
     downloadThread3.join();
 
-    ASSERT_EQ(boost::filesystem::file_size(boost::filesystem::path(g_tmpFileName)), g_smallFileSizeBytes);
-    ASSERT_EQ(boost::filesystem::file_size(boost::filesystem::path(g_tmpFileName2)), g_smallFileSizeBytes);
-    ASSERT_EQ(boost::filesystem::file_size(boost::filesystem::path(g_tmpFileName3)), g_smallFileSizeBytes);
+    ASSERT_EQ(std::filesystem::file_size(std::filesystem::path(g_tmpFileName)), g_smallFileSizeBytes);
+    ASSERT_EQ(std::filesystem::file_size(std::filesystem::path(g_tmpFileName2)), g_smallFileSizeBytes);
+    ASSERT_EQ(std::filesystem::file_size(std::filesystem::path(g_tmpFileName3)), g_smallFileSizeBytes);
 }
 
 TEST_F(DownloadTests, MultipleConcurrentDownloadTest_WithCancels)
@@ -546,9 +546,9 @@ TEST_F(DownloadTests, MultipleConcurrentDownloadTest_WithCancels)
     downloadThread2.join();
     downloadThread3.join();
 
-    ASSERT_EQ(boost::filesystem::file_size(boost::filesystem::path(g_tmpFileName)), g_smallFileSizeBytes);
-    ASSERT_FALSE(boost::filesystem::exists(g_tmpFileName2));
-    ASSERT_EQ(boost::filesystem::file_size(boost::filesystem::path(g_tmpFileName3)), g_smallFileSizeBytes);
+    ASSERT_EQ(std::filesystem::file_size(std::filesystem::path(g_tmpFileName)), g_smallFileSizeBytes);
+    ASSERT_FALSE(std::filesystem::exists(g_tmpFileName2));
+    ASSERT_EQ(std::filesystem::file_size(std::filesystem::path(g_tmpFileName3)), g_smallFileSizeBytes);
 }
 
 TEST_F(DownloadTests, FileDeletionAfterPause)
@@ -566,8 +566,8 @@ TEST_F(DownloadTests, FileDeletionAfterPause)
     auto status = largeDownload->get_status();
     ASSERT_EQ(status.state(), msdo::download_state::paused) << "Download is paused";
 
-    boost::filesystem::remove(g_tmpFileName2);
-    ASSERT_FALSE(boost::filesystem::exists(g_tmpFileName2)) << "Output file deleted";
+    std::filesystem::remove(g_tmpFileName2);
+    ASSERT_FALSE(std::filesystem::exists(g_tmpFileName2)) << "Output file deleted";
 
 #if defined(DO_CLIENT_AGENT)
     try
@@ -600,7 +600,7 @@ TEST_F(DownloadTests, SimpleBlockingDownloadTest_ClientNotRunning)
         });
     TestHelpers::DeleteRestPortFiles(); // can be removed if docs deletes file on shutdown
 
-    ASSERT_FALSE(boost::filesystem::exists(g_tmpFileName));
+    ASSERT_FALSE(std::filesystem::exists(g_tmpFileName));
     try
     {
         msdot::download::download_url_to_path(g_smallFileUrl, g_tmpFileName);
@@ -610,7 +610,7 @@ TEST_F(DownloadTests, SimpleBlockingDownloadTest_ClientNotRunning)
     {
         ASSERT_EQ(e.error_code().value(), msdo::errc::no_service);
     }
-    ASSERT_FALSE(boost::filesystem::exists(g_tmpFileName));
+    ASSERT_FALSE(std::filesystem::exists(g_tmpFileName));
 }
 
 TEST_F(DownloadTests, SimpleBlockingDownloadTest_ClientNotRunningPortFilePresent)
@@ -623,7 +623,7 @@ TEST_F(DownloadTests, SimpleBlockingDownloadTest_ClientNotRunningPortFilePresent
     TestHelpers::DeleteRestPortFiles();
     TestHelpers::CreateRestPortFiles(1);
 
-    ASSERT_FALSE(boost::filesystem::exists(g_tmpFileName));
+    ASSERT_FALSE(std::filesystem::exists(g_tmpFileName));
     try
     {
         msdot::download::download_url_to_path(g_smallFileUrl, g_tmpFileName);
@@ -633,7 +633,7 @@ TEST_F(DownloadTests, SimpleBlockingDownloadTest_ClientNotRunningPortFilePresent
     {
         ASSERT_EQ(e.error_code().value(), msdo::errc::no_service);
     }
-    ASSERT_FALSE(boost::filesystem::exists(g_tmpFileName));
+    ASSERT_FALSE(std::filesystem::exists(g_tmpFileName));
 }
 
 TEST_F(DownloadTests, MultipleRestPortFileExists_Download)
@@ -649,10 +649,10 @@ TEST_F(DownloadTests, MultipleRestPortFileExists_Download)
     std::this_thread::sleep_for(std::chrono::seconds(2));
     ASSERT_EQ(TestHelpers::CountRestPortFiles(), 1u) << "All other restport files must be deleted by the agent";
 
-    ASSERT_FALSE(boost::filesystem::exists(g_tmpFileName));
+    ASSERT_FALSE(std::filesystem::exists(g_tmpFileName));
     msdot::download::download_url_to_path(g_smallFileUrl, g_tmpFileName);
-    ASSERT_TRUE(boost::filesystem::exists(g_tmpFileName));
-    ASSERT_EQ(boost::filesystem::file_size(boost::filesystem::path(g_tmpFileName)), g_smallFileSizeBytes);
+    ASSERT_TRUE(std::filesystem::exists(g_tmpFileName));
+    ASSERT_EQ(std::filesystem::file_size(std::filesystem::path(g_tmpFileName)), g_smallFileSizeBytes);
 }
 
 #endif // DO_INTERFACE_REST

--- a/sdk-cpp/tests/rest/config_tests.cpp
+++ b/sdk-cpp/tests/rest/config_tests.cpp
@@ -4,7 +4,7 @@
 #include "tests_common.h"
 
 #include <cstring>
-#include <experimental/filesystem>
+#include <filesystem>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include "do_config.h"
@@ -12,7 +12,6 @@
 #include "test_data.h"
 #include "test_helpers.h"
 
-namespace cppfs = std::experimental::filesystem;
 namespace msdo = microsoft::deliveryoptimization;
 namespace msdod = microsoft::deliveryoptimization::details;
 
@@ -22,9 +21,9 @@ public:
     void SetUp() override
     {
         TestHelpers::CleanTestDir();
-        if (cppfs::exists(msdod::GetConfigFilePath()))
+        if (std::filesystem::exists(msdod::GetConfigFilePath()))
         {
-            cppfs::remove(msdod::GetConfigFilePath());
+            std::filesystem::remove(msdod::GetConfigFilePath());
         }
     }
 

--- a/sdk-cpp/tests/rest/mcc_download_tests.cpp
+++ b/sdk-cpp/tests/rest/mcc_download_tests.cpp
@@ -3,9 +3,9 @@
 
 #include "tests_common.h"
 
+#include <filesystem>
 #include <random>
 #include <thread>
-#include <experimental/filesystem>
 #include "do_config.h"
 #include "do_download.h"
 #include "do_download_status.h"
@@ -14,7 +14,6 @@
 #include "test_data.h"
 #include "test_helpers.h"
 
-namespace cppfs = std::experimental::filesystem;
 namespace msdo = microsoft::deliveryoptimization;
 namespace msdod = microsoft::deliveryoptimization::details;
 namespace msdot = microsoft::deliveryoptimization::test;
@@ -25,9 +24,9 @@ public:
     void SetUp() override
     {
         TestHelpers::CleanTestDir();
-        if (cppfs::exists(msdod::GetConfigFilePath()))
+        if (std::filesystem::exists(msdod::GetConfigFilePath()))
         {
-            cppfs::remove(msdod::GetConfigFilePath());
+            std::filesystem::remove(msdod::GetConfigFilePath());
         }
     }
 

--- a/sdk-cpp/tests/rest/network_connectivity_tests.cpp
+++ b/sdk-cpp/tests/rest/network_connectivity_tests.cpp
@@ -6,7 +6,7 @@
 #include <atomic>
 #include <thread>
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #include "do_download.h"
 #include "do_download_status.h"
@@ -65,7 +65,7 @@ TEST_F(NetworkConnectivityTests, DISABLED_SimpleBlockingDownloadNetworkReconnect
             try
             {
                 msdo::download::download_url_to_path(g_largeFileUrl, g_tmpFileName);
-                ASSERT_EQ(boost::filesystem::file_size(boost::filesystem::path(g_tmpFileName)), g_largeFileSizeBytes);
+                ASSERT_EQ(std::filesystem::file_size(std::filesystem::path(g_tmpFileName)), g_largeFileSizeBytes);
             }
             catch (const msdod::exception& e)
             {

--- a/sdk-cpp/tests/rest/port_discovery_tests.cpp
+++ b/sdk-cpp/tests/rest/port_discovery_tests.cpp
@@ -2,7 +2,7 @@
 
 #include <fstream>
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #include "do_persistence.h"
 #include "do_port_finder.h"
@@ -34,9 +34,9 @@ void PortDiscoveryTests::SetUp()
 {
     TestHelpers::StopService(g_docsSvcName); // ensure agent does not write to port file
     TestHelpers::DeleteRestPortFiles();
-    if (!boost::filesystem::exists(msdod::GetRuntimeDirectory()))
+    if (!std::filesystem::exists(msdod::GetRuntimeDirectory()))
     {
-        boost::filesystem::create_directories(msdod::GetRuntimeDirectory());
+        std::filesystem::create_directories(msdod::GetRuntimeDirectory());
     }
 
     std::ofstream file(_testFilePath);
@@ -45,9 +45,9 @@ void PortDiscoveryTests::SetUp()
 
 void PortDiscoveryTests::TearDown()
 {
-    if (boost::filesystem::exists(_testFilePath))
+    if (std::filesystem::exists(_testFilePath))
     {
-        boost::filesystem::remove(_testFilePath);
+        std::filesystem::remove(_testFilePath);
     }
     TestHelpers::StartService(g_docsSvcName);
 }

--- a/sdk-cpp/tests/rest/rest_interface_tests.cpp
+++ b/sdk-cpp/tests/rest/rest_interface_tests.cpp
@@ -3,9 +3,8 @@
 
 #include "tests_common.h"
 
+#include <filesystem>
 #include <fstream>
-#include <experimental/filesystem>
-namespace cppfs = std::experimental::filesystem;
 
 #include <boost/asio.hpp>
 using btcp_t = boost::asio::ip::tcp;
@@ -23,9 +22,9 @@ class RestInterfaceTests : public ::testing::Test
 public:
     void SetUp() override
     {
-        if (cppfs::exists(msdod::GetAdminConfigFilePath()))
+        if (std::filesystem::exists(msdod::GetAdminConfigFilePath()))
         {
-            cppfs::remove(msdod::GetAdminConfigFilePath());
+            std::filesystem::remove(msdod::GetAdminConfigFilePath());
         }
     }
 

--- a/sdk-cpp/tests/rest/test_helpers.cpp
+++ b/sdk-cpp/tests/rest/test_helpers.cpp
@@ -17,7 +17,7 @@
 #include <stdio.h>
 #include <signal.h>
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #include "do_persistence.h"
 #include "do_port_finder.h"
@@ -64,12 +64,12 @@ void TestHelpers::CreateRestPortFiles(int numFiles)
 
 void TestHelpers::DeleteRestPortFiles()
 {
-    for (boost::filesystem::directory_iterator itr(msdod::GetRuntimeDirectory()); itr != boost::filesystem::directory_iterator(); ++itr)
+    for (std::filesystem::directory_iterator itr(msdod::GetRuntimeDirectory()); itr != std::filesystem::directory_iterator(); ++itr)
     {
         auto& dirEntry = itr->path();
         if (dirEntry.filename().string().find("restport") != std::string::npos)
         {
-            boost::filesystem::remove(dirEntry);
+            std::filesystem::remove(dirEntry);
         }
     }
 }
@@ -77,7 +77,7 @@ void TestHelpers::DeleteRestPortFiles()
 unsigned int TestHelpers::CountRestPortFiles()
 {
     unsigned int count = 0;
-    for (boost::filesystem::directory_iterator itr(msdod::GetRuntimeDirectory()); itr != boost::filesystem::directory_iterator(); ++itr)
+    for (std::filesystem::directory_iterator itr(msdod::GetRuntimeDirectory()); itr != std::filesystem::directory_iterator(); ++itr)
     {
         auto& dirEntry = itr->path();
         if (dirEntry.filename().string().find("restport") != std::string::npos)

--- a/sdk-cpp/tests/test_data.cpp
+++ b/sdk-cpp/tests/test_data.cpp
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #include "test_data.h"
-#include "boost/filesystem.hpp"
+#include <filesystem>
 
 using namespace std::chrono_literals; // NOLINT(build/namespaces)
 
@@ -14,14 +14,14 @@ const uint64_t g_prodFileSizeBytes = 25006511u;
 // For testing production scenario, use the same path DU agent will use
 static const std::string downloadPath = "/var/lib/deviceupdate-agent-downloads";
 #else
-static const std::string downloadPath = boost::filesystem::temp_directory_path().string();
+static const std::string downloadPath = std::filesystem::temp_directory_path().string();
 #endif
 
 const std::string g_largeFileUrl = "http://main.oremdl.microsoft.com.nsatc.net/dotc/ReplacementDCATFile.txt";
 const std::string g_malformedFilePath = "?f309adfasdf///dfasdfj39fjasldfjasdf///           ///.1";
-const std::string g_tmpFileName = (downloadPath / boost::filesystem::path("docsdk_testfile.txt")).string();
-const std::string g_tmpFileName2 = (downloadPath / boost::filesystem::path("docsdk_testfile2.txt")).string();
-const std::string g_tmpFileName3 = (downloadPath / boost::filesystem::path("docsdk_testfile3.txt")).string();
+const std::string g_tmpFileName = (downloadPath / std::filesystem::path("docsdk_testfile.txt")).string();
+const std::string g_tmpFileName2 = (downloadPath / std::filesystem::path("docsdk_testfile2.txt")).string();
+const std::string g_tmpFileName3 = (downloadPath / std::filesystem::path("docsdk_testfile3.txt")).string();
 const std::string g_smallFileUrl = "http://main.oremdl.microsoft.com.nsatc.net/dotc/49c591d405d307e25e72a19f7e79b53d69f19954/43A54FC03C6A979E9AAEAE2493757D1429A5C8A8D093FB7B8103E8CC8DF7B6B6";
 const std::string g_smallFilePhfInfoJson = R"(
     {

--- a/sdk-cpp/tests/test_helpers.h
+++ b/sdk-cpp/tests/test_helpers.h
@@ -4,6 +4,7 @@
 #ifndef _DELIVERY_OPTIMIZATION_TEST_HELPERS_H
 #define _DELIVERY_OPTIMIZATION_TEST_HELPERS_H
 
+#include <filesystem>
 #include <string>
 #include <thread>
 
@@ -150,34 +151,34 @@ class TestHelpers
 public:
     static void CleanTestDir()
     {
-        if (boost::filesystem::exists(g_tmpFileName))
+        if (std::filesystem::exists(g_tmpFileName))
         {
-            boost::filesystem::remove(g_tmpFileName);
+            std::filesystem::remove(g_tmpFileName);
         }
-        if (boost::filesystem::exists(g_tmpFileName2))
+        if (std::filesystem::exists(g_tmpFileName2))
         {
-            boost::filesystem::remove(g_tmpFileName2);
+            std::filesystem::remove(g_tmpFileName2);
         }
-        if (boost::filesystem::exists(g_tmpFileName3))
+        if (std::filesystem::exists(g_tmpFileName3))
         {
-            boost::filesystem::remove(g_tmpFileName3);
+            std::filesystem::remove(g_tmpFileName3);
         }
     }
 
     // DoSvc creates temporary files with a unique name in the same directory as the output file
-    static void DeleteDoSvcTemporaryFiles(const boost::filesystem::path& outputFilePath)
+    static void DeleteDoSvcTemporaryFiles(const std::filesystem::path& outputFilePath)
     {
-        const boost::filesystem::path parentDir = outputFilePath.parent_path();
-        for (boost::filesystem::directory_iterator itr(parentDir); itr != boost::filesystem::directory_iterator(); ++itr)
+        const std::filesystem::path parentDir = outputFilePath.parent_path();
+        for (std::filesystem::directory_iterator itr(parentDir); itr != std::filesystem::directory_iterator(); ++itr)
         {
-            const boost::filesystem::directory_entry& dirEntry = *itr;
+            const std::filesystem::directory_entry& dirEntry = *itr;
             // Remove all files with names that match DO*.tmp
-            if (boost::filesystem::is_regular_file(dirEntry)
+            if (std::filesystem::is_regular_file(dirEntry)
                 && (dirEntry.path().filename().string().find("DO") == 0)
                 && (dirEntry.path().extension() == ".tmp"))
             {
-                boost::system::error_code ec;
-                boost::filesystem::remove(dirEntry, ec);
+                std::error_code ec;
+                std::filesystem::remove(dirEntry, ec);
                 if (ec)
                 {
                     std::cout << "Temp file deletion error: " << ec.message() << ", " << dirEntry.path() << '\n';

--- a/sdk-cpp/tests/tests_common.h
+++ b/sdk-cpp/tests/tests_common.h
@@ -4,7 +4,7 @@
 #ifndef _DELIVERY_OPTIMIZATION_TESTS_COMMON_H
 #define _DELIVERY_OPTIMIZATION_TESTS_COMMON_H
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 

--- a/snapcraft-options/snapcraft-agent.yaml
+++ b/snapcraft-options/snapcraft-agent.yaml
@@ -44,7 +44,6 @@ parts:
 
     stage-packages:
       - libasn1-8-heimdal
-      - libboost-filesystem1.71.0
       - libbrotli1
       - libcurl4
       - libgssapi3-heimdal

--- a/snapcraft-options/snapcraft-sdk.yaml
+++ b/snapcraft-options/snapcraft-sdk.yaml
@@ -46,7 +46,6 @@ parts:
 
     stage-packages:
       - libboost-program-options1.71.0
-      - libboost-filesystem1.71.0
 
 apps:
   sdk-tests:


### PR DESCRIPTION
Always wanted to move to the C++17 filesystem implementation. What prompted the change now: The FindBoost issue on Ubuntu 20.04 involving symlinking /lib to /usr/lib but /include being non-existent. This change removes public dependency on Boost libs entirely, leaving only the tests using boost::program_options.