### PR TITLE
Fix minsizerel binary size checks

### DIFF
--- a/azure-pipelines/build/linux/du/templates/doclient-lite-native-steps.yml
+++ b/azure-pipelines/build/linux/du/templates/doclient-lite-native-steps.yml
@@ -24,7 +24,7 @@ steps:
   inputs:
     targetType: 'filePath'
     filePath: 'build/scripts/check_binary_size.sh'
-    arguments: '1251928 /tmp/build-deliveryoptimization-agent/linux-${{parameters.config}}/client-lite/deliveryoptimization-agent'
+    arguments: '363928 /tmp/build-deliveryoptimization-agent/linux-${{parameters.config}}/client-lite/deliveryoptimization-agent'
   displayName: 'Limit binary size increase'
 
 - task: CmdLine@2

--- a/azure-pipelines/build/linux/du/templates/dosdkcpp-native-steps.yml
+++ b/azure-pipelines/build/linux/du/templates/dosdkcpp-native-steps.yml
@@ -38,7 +38,7 @@ steps:
   inputs:
     targetType: 'filePath'
     filePath: 'build/scripts/check_binary_size.sh'
-    arguments: '443632 /tmp/build-deliveryoptimization-sdk/linux-${{parameters.config}}/sdk-cpp/libdeliveryoptimization.so.*.*.*'
+    arguments: '431184 /tmp/build-deliveryoptimization-sdk/linux-${{parameters.config}}/sdk-cpp/libdeliveryoptimization.so.*.*.?'
   displayName: 'Limit binary size increase'
 
 - task: CmdLine@2

--- a/build/scripts/check_binary_size.sh
+++ b/build/scripts/check_binary_size.sh
@@ -22,8 +22,11 @@ do
   change_pct=`echo "scale=2; ($actual_size - $expected_size) / $expected_size * 100" | bc`
   echo Size check, expected = $expected_size, actual = $actual_size, change pct = $change_pct%
   change_pct=$( printf "%.0f" $change_pct )
-  if [ $change_pct -ge 5 ]; then
-      echo "Size check FAIL. Adjust expected_size if this increase is expected."
-      exit 3
+  if [ $change_pct -ge 2 ]; then
+    echo "[FAIL] Size increased beyond threshold. Adjust expected_size if this is expected."
+    exit 3
+  elif [ $change_pct -le -5 ]; then
+    echo "[WARNING] Size reduced beyond threshold. Adjust expected_size if this is expected."
+    exit 4
   fi
 done


### PR DESCRIPTION
* Agent binary size is much lower than the limit we were checking against. The limit probably was not updated after the earlier size reductions.
* SDK size is lower but only by a small margin. Updated that one too.
* Also update the script to fail if size has reduced too much in order to catch this early next time.