### PR TITLE
Adding support for building DO snaps for arm64 architecture

### DIFF
--- a/build/build-snaps.sh
+++ b/build/build-snaps.sh
@@ -22,7 +22,12 @@ then
         cp ./snapcraft-options/snapcraft-sdk.yaml ./snap/snapcraft.yaml
     fi
 
-    snapcraft
+    if [ $2 -a $2  == "arm64" ]
+    then
+        snapcraft --target-arch=arm64 --destructive-mode --enable-experimental-target-arch
+    else
+        snapcraft
+    fi
 
 else
     echo "$1 is not a valid snap option, valid options are 'agent' or 'sdk-tests'"

--- a/snapcraft-options/snapcraft-agent.yaml
+++ b/snapcraft-options/snapcraft-agent.yaml
@@ -8,6 +8,10 @@ description: |
 grade: devel # must be 'stable' to release into candidate/stable channels
 confinement: strict # use 'strict' once you have the right plugs and slots
 
+architectures:
+  - build-on: [amd64, arm64]
+    run-on: [amd64, armhf, arm64]
+
 #####
 #
 # Keywords

--- a/snapcraft-options/snapcraft-sdk.yaml
+++ b/snapcraft-options/snapcraft-sdk.yaml
@@ -8,6 +8,10 @@ description: |
 grade: devel # must be 'stable' to release into candidate/stable channels
 confinement: strict # use 'strict' once you have the right plugs and slots
 
+architectures:
+  - build-on: [amd64, arm64]
+    run-on: [amd64, armhf, arm64]
+
 #####
 #
 # Keywords
@@ -50,6 +54,9 @@ parts:
 apps:
   sdk-tests:
     command: bin/deliveryoptimization-sdk-tests
+    plugs:
+      - network
+      - network-bind
 
 plugs:
   do-port-numbers:

--- a/snapcraft-options/ubuntu-snap.md
+++ b/snapcraft-options/ubuntu-snap.md
@@ -10,13 +10,19 @@ Run the commands in the root of the repo.
     - `$ ./build/build-snaps.sh agent`
     - `$ ./build/build-snaps.sh sdk-tests`
 
+- **Building on ARM64 architecture**
+    - `$ ./build/build-snaps.sh agent arm64`
+    - `$ ./build/build-snaps.sh sdk-tests arm64`
+
+If the `arm64` argument is not provided then by default snapcraft will build the snap for `amd64` architecture.
+
 - By default snapcraft doesn't allow multiple snaps definition in the same code base, so this build-snaps.sh file was created so that
 we can copy the different snap files into the main snapcraft.yaml file and then build it.
 
 - Subsequent builds of the same component without modifying the corresponding yaml file:
     - `$ snapcraft`
 
-- The build will generate *.snap files in the current working directory. Example: **deliveryoptimization-sdk-tests_0.1_amd64.snap**.
+- The build will generate *.snap files in the current working directory. Example: **deliveryoptimization-sdk-tests_0.1_multi.snap**.
 
 - In the snapcraft.yaml the regular script to build for both the delivery optimization agent and sdk is called (`build.py`), but since
 there are some different behaviors the code should have when inside a snap, for that we use a flag `--build-for-snap` on the build.
@@ -26,8 +32,16 @@ file when you call the `build-snaps.sh` file.
     - `$ python3 ./build/build.py --project sdk --build-for-snap`  
 
 ## Installing
-- `$ sudo snap install --devmode ./deliveryoptimization-sdk-tests_0.1_amd64.snap`
-- `$ sudo snap install --devmode ./deliveryoptimization-client_0.1_amd64.snap`
+- `$ sudo snap install --devmode ./deliveryoptimization-sdk-tests_0.1_multi.snap`
+- `$ sudo snap install --devmode ./deliveryoptimization-client_0.1_multi.snap`
+
+Note that the `--devmode` flag is being used in the install command, this should be used in devmode confinment only. If the snap is in strict confinment then you can remove the flag.
+
+In case of metadata signatures error when running the install command, the `--dangerous` flag should be used. 
+The --dangerous flag in snapcraft bypasses the signature check, allowing you to install an unsigned Snap package.
+
+- `$ sudo snap install --dangerous ./deliveryoptimization-sdk-tests_0.1_multi.snap`
+- `$ sudo snap install --dangerous ./deliveryoptimization-client_0.1_multi.snap`
 
 ## The snap environment
 It is a fruitful exercise to look around in the host file system and see how snap structures the installed snaps. Look at these paths to start with:


### PR DESCRIPTION
- Adding support for building both the agent and sdk-tests snaps for arm64.
- Updated documentation for building for arm64.
- Adding network plug to sdk-test run in strict confinement.