### PR TITLE
Fix the nightly build pipelines

### DIFF
--- a/azure-pipelines/build/linux/du/templates/do-docker-jobs.yml
+++ b/azure-pipelines/build/linux/du/templates/do-docker-jobs.yml
@@ -19,7 +19,7 @@ jobs:
       targetOsArch: ${{parameters.targetOsArch}}
       imageVersion: ${{parameters.imageVersion}}
       config: debug
-      skipTests: ${{ contains(parameters.targetOsArch, '_arm') }}
+      skipTests: ${{ not(endswith(parameters.targetOsArch, '_x64')) }}
   - publish: $(Build.ArtifactStagingDirectory)
     artifact: 'doclient-drop-${{parameters.targetOsArch}}-debug'
 

--- a/azure-pipelines/build/linux/du/templates/do-docker-jobs.yml
+++ b/azure-pipelines/build/linux/du/templates/do-docker-jobs.yml
@@ -10,8 +10,8 @@ parameters:
   type: string
 
 jobs:
-# Build agents are running x64 architecture, so we don't run unit tests for ARM builds (built using docker+QEMU).
-# Build agents are currently running Ubuntu 18.04, so the tests are run only for Ubuntu 18.04 builds.
+# Build agents are running Ubuntu 18.04 on x64 architecture, so we don't run unit tests for ARM builds (built using docker+QEMU)
+# and other OS builds (test binary dependencies not installed).
 - job: ${{parameters.targetOsArch}}_debug
   steps:
   - template: ${{parameters.stepsTemplate}}

--- a/azure-pipelines/build/linux/du/templates/do-docker-jobs.yml
+++ b/azure-pipelines/build/linux/du/templates/do-docker-jobs.yml
@@ -10,8 +10,8 @@ parameters:
   type: string
 
 jobs:
-# Build agents are running x64 architecture, so we don't run unit tests for ARM builds.
-# The build itself uses docker containers with QEMU to target ARM.
+# Build agents are running x64 architecture, so we don't run unit tests for ARM builds (built using docker+QEMU).
+# Build agents are currently running Ubuntu 18.04, so the tests are run only for Ubuntu 18.04 builds.
 - job: ${{parameters.targetOsArch}}_debug
   steps:
   - template: ${{parameters.stepsTemplate}}
@@ -19,7 +19,7 @@ jobs:
       targetOsArch: ${{parameters.targetOsArch}}
       imageVersion: ${{parameters.imageVersion}}
       config: debug
-      skipTests: ${{ not(endswith(parameters.targetOsArch, '_x64')) }}
+      skipTests: ${{ ne(parameters.targetOsArch, 'ubuntu1804_x64') }}
   - publish: $(Build.ArtifactStagingDirectory)
     artifact: 'doclient-drop-${{parameters.targetOsArch}}-debug'
 

--- a/azure-pipelines/build/linux/du/templates/do-docker-jobs.yml
+++ b/azure-pipelines/build/linux/du/templates/do-docker-jobs.yml
@@ -10,6 +10,8 @@ parameters:
   type: string
 
 jobs:
+# Build agents are running x64 architecture, so we don't run unit tests for ARM builds.
+# The build itself uses docker containers with QEMU to target ARM.
 - job: ${{parameters.targetOsArch}}_debug
   steps:
   - template: ${{parameters.stepsTemplate}}
@@ -17,7 +19,7 @@ jobs:
       targetOsArch: ${{parameters.targetOsArch}}
       imageVersion: ${{parameters.imageVersion}}
       config: debug
-      skipTests: false
+      skipTests: ${{ contains(parameters.targetOsArch, '_arm') }}
   - publish: $(Build.ArtifactStagingDirectory)
     artifact: 'doclient-drop-${{parameters.targetOsArch}}-debug'
 

--- a/azure-pipelines/build/linux/du/templates/doclient-lite-docker-steps.yml
+++ b/azure-pipelines/build/linux/du/templates/doclient-lite-docker-steps.yml
@@ -36,9 +36,10 @@ steps:
     script: 'sudo docker run --rm --entrypoint=python3 -v $(Build.SourcesDirectory):/code -v /tmp/build-deliveryoptimization-agent-${{parameters.targetOsArch}}:/tmp/build-deliveryoptimization-agent doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.imageVersion}} "/code/build/build.py" "--clean" "--package-for" "DEB" "--config" "${{parameters.config}}" "--project" "agent"'
   displayName: 'Build client-lite ${{parameters.targetOsArch}}-${{parameters.config}}'
 
-# Testing binary size only on minsizerel+x64 is sufficient.
+# Binary size varies based on the target OS, architecture and build config.
+# Testing only on one variation is sufficient for now.
 - task: Bash@3
-  condition: and(eq('${{parameters.config}}', 'minsizerel'), endswith('${{parameters.targetOsArch}}', '_x64'))
+  condition: and(eq('${{parameters.config}}', 'minsizerel'), eq('${{parameters.targetOsArch}}', 'ubuntu1804_x64'))
   inputs:
     targetType: 'filePath'
     filePath: 'build/scripts/check_binary_size.sh'

--- a/azure-pipelines/build/linux/du/templates/doclient-lite-docker-steps.yml
+++ b/azure-pipelines/build/linux/du/templates/doclient-lite-docker-steps.yml
@@ -36,9 +36,9 @@ steps:
     script: 'sudo docker run --rm --entrypoint=python3 -v $(Build.SourcesDirectory):/code -v /tmp/build-deliveryoptimization-agent-${{parameters.targetOsArch}}:/tmp/build-deliveryoptimization-agent doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.imageVersion}} "/code/build/build.py" "--clean" "--package-for" "DEB" "--config" "${{parameters.config}}" "--project" "agent"'
   displayName: 'Build client-lite ${{parameters.targetOsArch}}-${{parameters.config}}'
 
-# Testing binary size only on x64+minsizerel is sufficient.
+# Testing binary size only on minsizerel+x64 is sufficient.
 - task: Bash@3
-  condition: ${{ and(eq('${{parameters.config}}', 'minsizerel'), !contains('${{parameters.targetOsArch}}', '_arm')) }}
+  condition: ${{ and(eq('${{parameters.config}}', 'minsizerel'), endswith('${{parameters.targetOsArch}}', '_x64')) }}
   inputs:
     targetType: 'filePath'
     filePath: 'build/scripts/check_binary_size.sh'

--- a/azure-pipelines/build/linux/du/templates/doclient-lite-docker-steps.yml
+++ b/azure-pipelines/build/linux/du/templates/doclient-lite-docker-steps.yml
@@ -45,10 +45,11 @@ steps:
     arguments: '523672 /tmp/build-deliveryoptimization-agent-${{parameters.targetOsArch}}/linux-${{parameters.config}}/client-lite/deliveryoptimization-agent'
   displayName: 'Limit binary size increase'
 
+# Use apt-get instead of dpkg to install the dependencies along with the package.
 - task: CmdLine@2
   condition: eq('${{parameters.skipTests}}', false)
   inputs:
-    script: 'sudo dpkg -i deliveryoptimization-agent*.deb'
+    script: 'sudo apt-get install ./deliveryoptimization-agent*.deb'
     workingDirectory: '/tmp/build-deliveryoptimization-agent-${{parameters.targetOsArch}}/linux-${{parameters.config}}'
   displayName: 'Install agent Debian package'
 

--- a/azure-pipelines/build/linux/du/templates/doclient-lite-docker-steps.yml
+++ b/azure-pipelines/build/linux/du/templates/doclient-lite-docker-steps.yml
@@ -45,11 +45,10 @@ steps:
     arguments: '523672 /tmp/build-deliveryoptimization-agent-${{parameters.targetOsArch}}/linux-${{parameters.config}}/client-lite/deliveryoptimization-agent'
   displayName: 'Limit binary size increase'
 
-# Use apt-get instead of dpkg to install the dependencies along with the package.
 - task: CmdLine@2
   condition: eq('${{parameters.skipTests}}', false)
   inputs:
-    script: 'sudo apt-get install ./deliveryoptimization-agent*.deb'
+    script: 'sudo dpkg -i deliveryoptimization-agent*.deb'
     workingDirectory: '/tmp/build-deliveryoptimization-agent-${{parameters.targetOsArch}}/linux-${{parameters.config}}'
   displayName: 'Install agent Debian package'
 

--- a/azure-pipelines/build/linux/du/templates/doclient-lite-docker-steps.yml
+++ b/azure-pipelines/build/linux/du/templates/doclient-lite-docker-steps.yml
@@ -36,8 +36,9 @@ steps:
     script: 'sudo docker run --rm --entrypoint=python3 -v $(Build.SourcesDirectory):/code -v /tmp/build-deliveryoptimization-agent-${{parameters.targetOsArch}}:/tmp/build-deliveryoptimization-agent doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.imageVersion}} "/code/build/build.py" "--clean" "--package-for" "DEB" "--config" "${{parameters.config}}" "--project" "agent"'
   displayName: 'Build client-lite ${{parameters.targetOsArch}}-${{parameters.config}}'
 
+# Testing binary size only on x64+minsizerel is sufficient.
 - task: Bash@3
-  condition: eq('${{parameters.config}}', 'minsizerel')
+  condition: and(eq('${{parameters.config}}', 'minsizerel'), !contains('${{parameters.targetOsArch}}', '_arm'))
   inputs:
     targetType: 'filePath'
     filePath: 'build/scripts/check_binary_size.sh'

--- a/azure-pipelines/build/linux/du/templates/doclient-lite-docker-steps.yml
+++ b/azure-pipelines/build/linux/du/templates/doclient-lite-docker-steps.yml
@@ -38,7 +38,7 @@ steps:
 
 # Testing binary size only on minsizerel+x64 is sufficient.
 - task: Bash@3
-  condition: ${{ and(eq('${{parameters.config}}', 'minsizerel'), endswith('${{parameters.targetOsArch}}', '_x64')) }}
+  condition: and(eq('${{parameters.config}}', 'minsizerel'), endswith('${{parameters.targetOsArch}}', '_x64'))
   inputs:
     targetType: 'filePath'
     filePath: 'build/scripts/check_binary_size.sh'

--- a/azure-pipelines/build/linux/du/templates/doclient-lite-docker-steps.yml
+++ b/azure-pipelines/build/linux/du/templates/doclient-lite-docker-steps.yml
@@ -38,7 +38,7 @@ steps:
 
 # Testing binary size only on x64+minsizerel is sufficient.
 - task: Bash@3
-  condition: and(eq('${{parameters.config}}', 'minsizerel'), !contains('${{parameters.targetOsArch}}', '_arm'))
+  condition: ${{ and(eq('${{parameters.config}}', 'minsizerel'), !contains('${{parameters.targetOsArch}}', '_arm')) }}
   inputs:
     targetType: 'filePath'
     filePath: 'build/scripts/check_binary_size.sh'

--- a/azure-pipelines/build/linux/du/templates/dopapt-docker-steps.yml
+++ b/azure-pipelines/build/linux/du/templates/dopapt-docker-steps.yml
@@ -33,19 +33,6 @@ steps:
 
 - task: CmdLine@2
   inputs:
-    script: 'sudo docker run --rm --entrypoint=python3 -v $(Build.SourcesDirectory):/code -v /tmp/build-deliveryoptimization-sdk-${{parameters.targetOsArch}}:/tmp/build-deliveryoptimization-sdk doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.imageVersion}} "/code/build/build.py" "--clean" "--package-for" "DEB" "--config" "${{parameters.config}}" "--project" "sdk"'
-    workingDirectory: '$(Build.SourcesDirectory)/build'
-  displayName: 'Build sdk ${{parameters.targetOsArch}}-${{parameters.config}}'
-
-- task: Bash@3
-  inputs:
-    targetType: 'inline'
-    script: 'sudo dpkg --ignore-depends=deliveryoptimization-agent -i libdeliveryoptimization*.deb'
-    workingDirectory: '/tmp/build-deliveryoptimization-sdk-${{parameters.targetOsArch}}/linux-${{parameters.config}}'
-  displayName: 'Install libdeliveryoptimization'
-
-- task: CmdLine@2
-  inputs:
     script: 'sudo docker run --rm --entrypoint=/bin/bash -v $(Build.SourcesDirectory):/code -v /tmp/build-deliveryoptimization-plugin-apt-${{parameters.targetOsArch}}:/tmp/build-deliveryoptimization-plugin-apt doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.imageVersion}} "/code/build/docker/docker-build-plugin.sh" "/code" "${{parameters.config}}"'
   displayName: 'Build deliveryoptimization-plugin-apt ${{parameters.targetOsArch}}-${{parameters.config}}'
 
@@ -58,18 +45,6 @@ steps:
     filePath: 'build/scripts/check_binary_size.sh'
     arguments: '150824 /tmp/build-deliveryoptimization-plugin-apt-${{parameters.targetOsArch}}/linux-${{parameters.config}}/plugins/linux-apt/deliveryoptimization-plugin-apt'
   displayName: 'Limit binary size increase'
-
-- task: CmdLine@2
-  condition: eq('${{parameters.skipTests}}', false)
-  inputs:
-    script: 'sudo dpkg -i deliveryoptimization-plugin-apt*.deb'
-    workingDirectory: '/tmp/build-deliveryoptimization-plugin-apt-${{parameters.targetOsArch}}/linux-${{parameters.config}}'
-  displayName: 'Install deliveryoptimization-plugin-apt'
-
-- task: CmdLine@2
-  inputs:
-    script: 'sudo dpkg -r libdeliveryoptimization-dev deliveryoptimization-plugin-apt libdeliveryoptimization'
-  displayName: 'Remove Packages'
 
 - task: CopyFiles@2
   inputs:

--- a/azure-pipelines/build/linux/du/templates/dopapt-docker-steps.yml
+++ b/azure-pipelines/build/linux/du/templates/dopapt-docker-steps.yml
@@ -49,8 +49,9 @@ steps:
     script: 'sudo docker run --rm --entrypoint=/bin/bash -v $(Build.SourcesDirectory):/code -v /tmp/build-deliveryoptimization-plugin-apt-${{parameters.targetOsArch}}:/tmp/build-deliveryoptimization-plugin-apt doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.imageVersion}} "/code/build/docker/docker-build-plugin.sh" "/code" "${{parameters.config}}"'
   displayName: 'Build deliveryoptimization-plugin-apt ${{parameters.targetOsArch}}-${{parameters.config}}'
 
+# Testing binary size only on x64+minsizerel is sufficient.
 - task: Bash@3
-  condition: eq('${{parameters.config}}', 'minsizerel')
+  condition: and(eq('${{parameters.config}}', 'minsizerel'), !contains('${{parameters.targetOsArch}}', '_arm'))
   inputs:
     targetType: 'filePath'
     filePath: 'build/scripts/check_binary_size.sh'

--- a/azure-pipelines/build/linux/du/templates/dopapt-docker-steps.yml
+++ b/azure-pipelines/build/linux/du/templates/dopapt-docker-steps.yml
@@ -51,7 +51,7 @@ steps:
 
 # Testing binary size only on minsizerel+x64 is sufficient.
 - task: Bash@3
-  condition: and(eq('${{parameters.config}}', 'minsizerel'), !contains('${{parameters.targetOsArch}}', '_arm'))
+  condition: ${{ and(eq('${{parameters.config}}', 'minsizerel'), endswith('${{parameters.targetOsArch}}', '_x64')) }}
   inputs:
     targetType: 'filePath'
     filePath: 'build/scripts/check_binary_size.sh'

--- a/azure-pipelines/build/linux/du/templates/dopapt-docker-steps.yml
+++ b/azure-pipelines/build/linux/du/templates/dopapt-docker-steps.yml
@@ -49,9 +49,10 @@ steps:
     script: 'sudo docker run --rm --entrypoint=/bin/bash -v $(Build.SourcesDirectory):/code -v /tmp/build-deliveryoptimization-plugin-apt-${{parameters.targetOsArch}}:/tmp/build-deliveryoptimization-plugin-apt doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.imageVersion}} "/code/build/docker/docker-build-plugin.sh" "/code" "${{parameters.config}}"'
   displayName: 'Build deliveryoptimization-plugin-apt ${{parameters.targetOsArch}}-${{parameters.config}}'
 
-# Testing binary size only on minsizerel+x64 is sufficient.
+# Binary size varies based on the target OS, architecture and build config.
+# Testing only on one variation is sufficient for now.
 - task: Bash@3
-  condition: ${{ and(eq('${{parameters.config}}', 'minsizerel'), endswith('${{parameters.targetOsArch}}', '_x64')) }}
+  condition: and(eq('${{parameters.config}}', 'minsizerel'), eq('${{parameters.targetOsArch}}', 'ubuntu1804_x64'))
   inputs:
     targetType: 'filePath'
     filePath: 'build/scripts/check_binary_size.sh'

--- a/azure-pipelines/build/linux/du/templates/dopapt-docker-steps.yml
+++ b/azure-pipelines/build/linux/du/templates/dopapt-docker-steps.yml
@@ -49,7 +49,7 @@ steps:
     script: 'sudo docker run --rm --entrypoint=/bin/bash -v $(Build.SourcesDirectory):/code -v /tmp/build-deliveryoptimization-plugin-apt-${{parameters.targetOsArch}}:/tmp/build-deliveryoptimization-plugin-apt doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.imageVersion}} "/code/build/docker/docker-build-plugin.sh" "/code" "${{parameters.config}}"'
   displayName: 'Build deliveryoptimization-plugin-apt ${{parameters.targetOsArch}}-${{parameters.config}}'
 
-# Testing binary size only on x64+minsizerel is sufficient.
+# Testing binary size only on minsizerel+x64 is sufficient.
 - task: Bash@3
   condition: and(eq('${{parameters.config}}', 'minsizerel'), !contains('${{parameters.targetOsArch}}', '_arm'))
   inputs:

--- a/azure-pipelines/build/linux/du/templates/dosdkcpp-docker-steps.yml
+++ b/azure-pipelines/build/linux/du/templates/dosdkcpp-docker-steps.yml
@@ -49,9 +49,10 @@ steps:
     script: 'sudo docker run --rm --entrypoint=python3 -v $(Build.SourcesDirectory):/code -v /tmp/build-deliveryoptimization-sdk-${{parameters.targetOsArch}}:/tmp/build-deliveryoptimization-sdk doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.imageVersion}} "/code/build/build.py" "--clean" "--package-for" "DEB" "--config" "${{parameters.config}}" "--project" "sdk"'
   displayName: 'Build sdk-cpp ${{parameters.targetOsArch}}-${{parameters.config}}'
 
-# Testing binary size only on minsizerel+x64 is sufficient.
+# Binary size varies based on the target OS, architecture and build config.
+# Testing only on one variation is sufficient for now.
 - task: Bash@3
-  condition: ${{ and(eq('${{parameters.config}}', 'minsizerel'), endswith('${{parameters.targetOsArch}}', '_x64')) }}
+  condition: and(eq('${{parameters.config}}', 'minsizerel'), eq('${{parameters.targetOsArch}}', 'ubuntu1804_x64'))
   inputs:
     targetType: 'filePath'
     filePath: 'build/scripts/check_binary_size.sh'

--- a/azure-pipelines/build/linux/du/templates/dosdkcpp-docker-steps.yml
+++ b/azure-pipelines/build/linux/du/templates/dosdkcpp-docker-steps.yml
@@ -49,8 +49,9 @@ steps:
     script: 'sudo docker run --rm --entrypoint=python3 -v $(Build.SourcesDirectory):/code -v /tmp/build-deliveryoptimization-sdk-${{parameters.targetOsArch}}:/tmp/build-deliveryoptimization-sdk doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.imageVersion}} "/code/build/build.py" "--clean" "--package-for" "DEB" "--config" "${{parameters.config}}" "--project" "sdk"'
   displayName: 'Build sdk-cpp ${{parameters.targetOsArch}}-${{parameters.config}}'
 
+# Testing binary size only on x64+minsizerel is sufficient.
 - task: Bash@3
-  condition: eq('${{parameters.config}}', 'minsizerel')
+  condition: and(eq('${{parameters.config}}', 'minsizerel'), !contains('${{parameters.targetOsArch}}', '_arm'))
   inputs:
     targetType: 'filePath'
     filePath: 'build/scripts/check_binary_size.sh'

--- a/azure-pipelines/build/linux/du/templates/dosdkcpp-docker-steps.yml
+++ b/azure-pipelines/build/linux/du/templates/dosdkcpp-docker-steps.yml
@@ -51,7 +51,7 @@ steps:
 
 # Testing binary size only on minsizerel+x64 is sufficient.
 - task: Bash@3
-  condition: and(eq('${{parameters.config}}', 'minsizerel'), !contains('${{parameters.targetOsArch}}', '_arm'))
+  condition: ${{ and(eq('${{parameters.config}}', 'minsizerel'), endswith('${{parameters.targetOsArch}}', '_x64')) }}
   inputs:
     targetType: 'filePath'
     filePath: 'build/scripts/check_binary_size.sh'

--- a/azure-pipelines/build/linux/du/templates/dosdkcpp-docker-steps.yml
+++ b/azure-pipelines/build/linux/du/templates/dosdkcpp-docker-steps.yml
@@ -49,7 +49,7 @@ steps:
     script: 'sudo docker run --rm --entrypoint=python3 -v $(Build.SourcesDirectory):/code -v /tmp/build-deliveryoptimization-sdk-${{parameters.targetOsArch}}:/tmp/build-deliveryoptimization-sdk doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.imageVersion}} "/code/build/build.py" "--clean" "--package-for" "DEB" "--config" "${{parameters.config}}" "--project" "sdk"'
   displayName: 'Build sdk-cpp ${{parameters.targetOsArch}}-${{parameters.config}}'
 
-# Testing binary size only on x64+minsizerel is sufficient.
+# Testing binary size only on minsizerel+x64 is sufficient.
 - task: Bash@3
   condition: and(eq('${{parameters.config}}', 'minsizerel'), !contains('${{parameters.targetOsArch}}', '_arm'))
   inputs:

--- a/build/docker/docker-build-plugin.sh
+++ b/build/docker/docker-build-plugin.sh
@@ -12,12 +12,20 @@ echo "Building apt plugin within Docker on Linux container"
 
 echo "Building & Installing sdk from source"
 cd $1
-python3 build/build.py --project sdk --cmaketarget deliveryoptimization --config $2 --clean
-cd /tmp/build-deliveryoptimization-sdk/linux-$2/
-cmake --build . --target install
+python3 build/build.py --project sdk --cmaketarget deliveryoptimization --config $2 --package-for DEB --clean
+pushd "/tmp/build-deliveryoptimization-sdk/linux-$2"
+dpkg --ignore-depends=deliveryoptimization-agent -i libdeliveryoptimization*.deb
+popd
 
-cd $1
 echo "Building linux-apt plugin from source"
 python3 build/build.py --project plugin-apt --config $2 --package-for debian --clean
 
 echo "Build of doclient-plugin completed"
+
+echo "Installing the plugin package"
+pushd "/tmp/build-deliveryoptimization-plugin-apt/linux-$2/"
+dpkg -i deliveryoptimization-plugin-apt*.deb
+popd
+
+echo "Removing packages"
+dpkg -r libdeliveryoptimization-dev deliveryoptimization-plugin-apt libdeliveryoptimization

--- a/build/docker/docker-build-plugin.sh
+++ b/build/docker/docker-build-plugin.sh
@@ -10,22 +10,27 @@ set -e
 
 echo "Building apt plugin within Docker on Linux container"
 
-echo "Building & Installing sdk from source"
+echo "***********************************************"
+echo "**** Building & Installing sdk from source ****"
+echo "***********************************************"
 cd $1
 python3 build/build.py --project sdk --cmaketarget deliveryoptimization --config $2 --package-for DEB --clean
 pushd "/tmp/build-deliveryoptimization-sdk/linux-$2"
+echo "**** Installing sdk package ****"
 dpkg --ignore-depends=deliveryoptimization-agent -i libdeliveryoptimization*.deb
 popd
 
-echo "Building linux-apt plugin from source"
+echo "***********************************************"
+echo "**** Building linux-apt plugin from source ****"
+echo "***********************************************"
 python3 build/build.py --project plugin-apt --config $2 --package-for debian --clean
 
-echo "Build of doclient-plugin completed"
-
-echo "Installing the plugin package"
+echo "***************************************"
+echo "**** Installing the plugin package ****"
+echo "***************************************"
 pushd "/tmp/build-deliveryoptimization-plugin-apt/linux-$2/"
 dpkg -i deliveryoptimization-plugin-apt*.deb
 popd
 
-echo "Removing packages"
+echo "**** Removing packages ****"
 dpkg -r libdeliveryoptimization-dev deliveryoptimization-plugin-apt libdeliveryoptimization


### PR DESCRIPTION
The previous work to move PR pipeline to docker-based builds enabled more steps to run on the nightly pipelines. This is not expected to work, and this change skips the steps appropriately.