### PR TITLE
Use new ACR svc connection that employs workload identity federation

### DIFF
--- a/azure-pipelines/build/linux/du/templates/doclient-lite-docker-steps.yml
+++ b/azure-pipelines/build/linux/du/templates/doclient-lite-docker-steps.yml
@@ -16,14 +16,14 @@ steps:
   displayName: Login to ACR
   inputs:
     command: login
-    containerRegistry: doclient-dockercontainerregistry-buildpipeline   # name of the service connection that connect the pipeline to the ACR
+    containerRegistry: doclient-dockercontainerregistry-buildpipeline-02   # name of the service connection that connect the pipeline to the ACR
     repository: $(parameters.targetOsArch)
 
 - task: Docker@2
   displayName: Pull latest build image
   inputs:
     command: pull
-    containerRegistry: doclient-dockercontainerregistry-buildpipeline   # name of the service connection that connect the pipeline to the ACR
+    containerRegistry: doclient-dockercontainerregistry-buildpipeline-02   # name of the service connection that connect the pipeline to the ACR
     arguments: 'doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.imageVersion}}'
 
 - task: CmdLine@2

--- a/azure-pipelines/build/linux/du/templates/dopapt-docker-steps.yml
+++ b/azure-pipelines/build/linux/du/templates/dopapt-docker-steps.yml
@@ -16,14 +16,14 @@ steps:
   displayName: Login to ACR
   inputs:
     command: login
-    containerRegistry: doclient-dockercontainerregistry-buildpipeline   # name of the service connection that connect the pipeline to the ACR
+    containerRegistry: doclient-dockercontainerregistry-buildpipeline-02   # name of the service connection that connect the pipeline to the ACR
     repository: $(parameters.targetOsArch)
 
 - task: Docker@2
   displayName: Pull latest build image
   inputs:
     command: pull
-    containerRegistry: doclient-dockercontainerregistry-buildpipeline   # name of the service connection that connect the pipeline to the ACR
+    containerRegistry: doclient-dockercontainerregistry-buildpipeline-02   # name of the service connection that connect the pipeline to the ACR
     arguments: 'doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.imageVersion}}'
 
 - task: CmdLine@2

--- a/azure-pipelines/build/linux/du/templates/dosdkcpp-docker-steps.yml
+++ b/azure-pipelines/build/linux/du/templates/dosdkcpp-docker-steps.yml
@@ -16,14 +16,14 @@ steps:
   displayName: Login to ACR
   inputs:
     command: login
-    containerRegistry: doclient-dockercontainerregistry-buildpipeline   # name of the service connection that connect the pipeline to the ACR
+    containerRegistry: doclient-dockercontainerregistry-buildpipeline-02   # name of the service connection that connect the pipeline to the ACR
     repository: $(parameters.targetOsArch)
 
 - task: Docker@2
   displayName: Pull latest build image
   inputs:
     command: pull
-    containerRegistry: doclient-dockercontainerregistry-buildpipeline   # name of the service connection that connect the pipeline to the ACR
+    containerRegistry: doclient-dockercontainerregistry-buildpipeline-02   # name of the service connection that connect the pipeline to the ACR
     arguments: 'doclientcontainerregistry.azurecr.io/${{parameters.targetOsArch}}:${{parameters.imageVersion}}'
 
 - task: CmdLine@2


### PR DESCRIPTION
- The old service connection was disabled due to use of service principal and secrets-based auth.
- Created a new service connection using workload identity federation. Updating the pipelines to use this now.