### PR TITLE
[Edge] Fix libcpp compatibility issues

### DIFF
--- a/sdk-cpp/src/internal/com/do_config_internal.cpp
+++ b/sdk-cpp/src/internal/com/do_config_internal.cpp
@@ -1,4 +1,4 @@
-
+#include <cstdlib>
 #include "do_config_internal.h"
 
 #include "do_errors.h"


### PR DESCRIPTION
To use `free`, we need to import `<cstdlib>`. This is transitively available here through `<cstdint>` in `do_errors.h` with some libcpp builds, but not all, including some recent ones. For spec compliance, we need to explicitly specify it.