### PR TITLE
[Edge] Remove extra qualification

### DIFF
--- a/sdk-cpp/src/internal/download_impl.h
+++ b/sdk-cpp/src/internal/download_impl.h
@@ -48,7 +48,7 @@ public:
 
 private:
 #if defined(DO_INTERFACE_COM)
-    static std::error_code CDownloadImpl::_EnumDownloads(const DO_DOWNLOAD_ENUM_CATEGORY* pCategory, std::vector<std::unique_ptr<IDownload>>& out) noexcept;
+    static std::error_code _EnumDownloads(const DO_DOWNLOAD_ENUM_CATEGORY* pCategory, std::vector<std::unique_ptr<IDownload>>& out) noexcept;
 
     Microsoft::WRL::ComPtr<IDODownload> _spDownload;
     std::unique_ptr<DO_DOWNLOAD_RANGES_INFO> _spRanges;


### PR DESCRIPTION
The function here is already in CDownloadImpl, and thus we get a warning under -Wmicrosoft-extra-qualification if we specify that again on the function line.