### PR TITLE
Add build support for Debian 12

### DIFF
--- a/build/scripts/bootstrap.sh
+++ b/build/scripts/bootstrap.sh
@@ -78,9 +78,9 @@ function installBuildDependencies
         mkdir /tmp/gtest
         pushd /tmp/gtest
 
-        if [[ ($DISTRO == "ubuntu" && ($VER == "20.04" || $VER == "22.04")) || ($DISTRO == "debian" && ($VER == "10" || $VER == "11")) ]];
+        if [[ ($DISTRO == "ubuntu" && ($VER == "20.04" || $VER == "22.04")) || ($DISTRO == "debian" && ($VER == "10" || $VER == "11" || $VER == "12")) ]];
         then
-            if [[ $VER == "22.04" ]]; then release="v1.13.0"; else release="release-1.10.0"; fi;
+            if [[ $VER == "22.04" || $VER == "12" ]]; then release="v1.13.0"; else release="release-1.10.0"; fi;
 
             # The latest native-version of gtest on the latest versions of ubuntu and debian currently has a bug where
             # CMakeLists doesn't declare an install target, causing 'make install' to fail.


### PR DESCRIPTION
The change made in https://github.com/microsoft/do-client/pull/195 was not enough to build in the context of iot-hub-device-update.

Example of the issue:
https://github.com/D-r-P-3-p-p-3-r/iot-hub-device-update/actions/runs/13783774384/job/38546993443#step:5:3595

Example Debian 12 build based on this PR with release `v1.13.0` being used that fixes `make: *** No rule to make target 'install'.  Stop.`

https://github.com/AndreRicardo-Zoetis/iot-hub-device-update/actions/runs/13908353423/job/38916535799#step:5:3594
