### PR TITLE
Update release pipeline and fix FileDeletionAfterPause test

### DIFF
--- a/azure-pipelines/publishing/github-release.yml
+++ b/azure-pipelines/publishing/github-release.yml
@@ -23,12 +23,17 @@ parameters:
     - debian11_arm32
     - debian11_arm64
     - debian11_x64
+    - debian12_arm32
+    - debian12_arm64
+    - debian12_x64
     - ubuntu1804_arm64
     - ubuntu1804_x64
     - ubuntu2004_arm64
     - ubuntu2004_x64
     - ubuntu2204_arm64
     - ubuntu2204_x64
+    - ubuntu2404_arm64
+    - ubuntu2404_x64
 
 - name: SkipPublishing
   displayName: Skip publishing step

--- a/sdk-cpp/tests/download_tests_common.cpp
+++ b/sdk-cpp/tests/download_tests_common.cpp
@@ -585,12 +585,13 @@ TEST_F(DownloadTests, FileDeletionAfterPause)
     auto status = largeDownload->get_status();
     // Download sometimes is too quick and completes before pause is called.
     // Could improve the test to ensure it always pauses but not worth it at this time.
-    EXPECT_EQ(status.state(), msdo::download_state::paused) << "Download is paused";
     if (status.state() == msdo::download_state::transferred)
     {
         std::cout << "Download completed too soon, skipping rest of test\n";
         return;
     }
+
+    ASSERT_EQ(status.state(), msdo::download_state::paused) << "Download is paused";
 
     fs::remove(g_tmpFileName2);
     ASSERT_FALSE(fs::exists(g_tmpFileName2)) << "Output file deleted";


### PR DESCRIPTION
* Add Debian12 and Ubuntu2404 in the release pipeline.
* Fix flaky test in SDK common tests.