### PR TITLE
[Edge] Add string include to do_error_helpers.h

### DIFF
--- a/sdk-cpp/src/internal/do_error_helpers.h
+++ b/sdk-cpp/src/internal/do_error_helpers.h
@@ -5,6 +5,7 @@
 #define _DELIVERY_OPTIMIZATION_DO_ERROR_HELPERS_H
 
 #include <cstdint>
+#include <string>
 #include <system_error>
 
 #ifdef DO_ENABLE_EXCEPTIONS


### PR DESCRIPTION
We're doing a stricter IWYU pass on libc++ usage in Edge, and ran into this file using string without explicitly including it. This fixes the bug and lets our stricter checks get significantly further.